### PR TITLE
Update hybrid to be compatible with latest version of vHLLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ function(run_one_energy
     set(smash_IC_oscar "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results/${system}_${energy}/${i}/IC/SMASH_IC.oscar")
     set(smash_IC_config "${CMAKE_CURRENT_SOURCE_DIR}/configs/smash_initial_conditions_${system}.yaml")
     set(vhlle_default_config "${CMAKE_CURRENT_SOURCE_DIR}/configs/vhlle_hydro")
+    set(vhlle_output_dir "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results/${system}_${energy}/${i}/Hydro/")
     set(vhlle_updated_config "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results/${system}_${energy}/${i}/Hydro/vhlle_config")
     set(vhlle_freezeout_hypersurface "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results/${system}_${energy}/${i}/Hydro/freezeout.dat")
     set(sampler_input_hypersurface "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results/${system}_${energy}/${i}/Sampler/freezeout.dat")
@@ -165,8 +166,10 @@ function(run_one_energy
     # Run hydro
     add_custom_command(OUTPUT "${vhlle_freezeout_hypersurface}"
     COMMAND "${CMAKE_BINARY_DIR}/hlle_visc"
-            "${vhlle_updated_config}"
-            ">" "${results_folder}/${i}/Hydro/Terminal_Output.txt"
+            "-params" "${vhlle_updated_config}"
+            "-ISinput" "${smash_IC_file}"
+            "-outputDir" "${vhlle_output_dir}"
+            ">" "${vhlle_output_dir}/Terminal_Output.txt"
     DEPENDS
             "${vhlle_updated_config}"
             "${CMAKE_BINARY_DIR}/hlle_visc"

--- a/configs/vhlle_hydro
+++ b/configs/vhlle_hydro
@@ -1,5 +1,3 @@
-outputDir       path/to/output/directory
-
 eosType       1
 eosTypeHadron 1
 
@@ -20,7 +18,6 @@ etamax    5.0
 tauGridResize 20.0
 
 icModel    6
-icInputFile path/to/initial/particle/list
 Rg      1.4      # to be updated
 Rgz     1.0      # to be updated
 

--- a/python_scripts/check_conservation.py
+++ b/python_scripts/check_conservation.py
@@ -118,7 +118,7 @@ def energy_from_hydro(file):
     E_before = 0.0
     for index, line in enumerate(f.readlines()):
         # skip header
-        if index <= 37: continue
+        if index <= 42: continue
         if line.startswith('corona'):
             NB_corona = baryon_number
             continue
@@ -191,7 +191,7 @@ def plotting_E_conservation(IC_energy, Specs_energy, hydro_energy, Sampler_energ
     plt.savefig(args.output_path + '/Energy_Conservation.pdf')
     plt.close()
 
-def plotting_NB_conservation(IC_NB, hydro_NB, Sampler_NB, Final_State_NB):
+def plotting_NB_conservation(IC_NB, Specs_NB, hydro_NB, Sampler_NB, Final_State_NB):
 
     Nevents = int(args.Nevents)
     x = np.arange(1, len(Sampler_NB) + 1, 1)
@@ -201,7 +201,7 @@ def plotting_NB_conservation(IC_NB, hydro_NB, Sampler_NB, Final_State_NB):
 
     plt.plot(x, [IC_NB]*Nevents, label = r'SMASH: Initial N$_\mathsf{B - \bar{B}}$', color = 'darkred', lw = 2)
     plt.bar(x, Sampler_NB, alpha = 0.3, label = r'Sampler: N$_\mathsf{B - \bar{B}}$ per Event')
-    plt.plot(x, [hydro_NB]*Nevents, label = r'Hydro: N$_\mathsf{B - \bar{B}}$', color = 'green', lw = 2)
+    plt.plot(x, [Specs_NB + hydro_NB]*Nevents, label = r'Hydro: N$_\mathsf{B - \bar{B}}$', color = 'green', lw = 2)
     plt.plot(x, [np.mean(Sampler_NB)]*Nevents, label = r'Sampler: Mean N$_\mathsf{B - \bar{B}}$', color = 'midnightblue', lw = 2)
     plt.plot(x, [Final_State_NB]*Nevents, label = r'SMASH: Final State N$_\mathsf{B - \bar{B}}$', color = 'orange', lw = 2, ls = '--')
     plt.legend(title = r'$\Delta$N$_\mathsf{B}$ = ' + str(round(100*(np.mean(Final_State_NB)/IC_NB - 1),2)) + ' %')
@@ -244,7 +244,7 @@ if __name__ == '__main__':
 
 
     plotting_E_conservation(E_SMASH_IC, E_SMASH_IC_specs[0], E_hydro, E_sampler_per_Event, E_sampler_per_Event_no_specs, E_SMASH_final_state)
-    plotting_NB_conservation(NB_SMASH_IC, NB_hydro, NB_sampler_per_Event, NB_SMASH_final_state)
+    plotting_NB_conservation(NB_SMASH_IC, NB_SMASH_IC_specs[0], NB_hydro, NB_sampler_per_Event, NB_SMASH_final_state)
 
     print 'Initial SMASH energy: ' + str(E_SMASH_IC[0])
     print 'Spectator energy: ' + str(E_SMASH_IC_specs)

--- a/python_scripts/create_vhlle_config.py
+++ b/python_scripts/create_vhlle_config.py
@@ -46,12 +46,8 @@ config_updated = open(args.output_file, 'w')
 with open(args.vhlle_config, 'r') as f:
     for line in f:
         if line[0] != '\n':
-            if line.split()[0] == 'outputDir':
-                newline = 'outputDir       ' + basepath + 'Hydro/' + '\n'
-            elif line.split()[0] == 'etaS':
+            if line.split()[0] == 'etaS':
                 newline = 'etaS      ' + str(hydro_params[energy]['etaS']) + '\n'
-            elif line.split()[0] == 'icInputFile':
-                newline = 'icInputFile       ' + basepath + 'IC/SMASH_IC.dat' + '\n'
             elif line.split()[0] == 'Rg':
                 newline = 'Rg      ' + str(hydro_params[energy]['Rg']) + '\n'
             elif line.split()[0] == 'Rgz':


### PR DESCRIPTION
* In vHLLE, the initialization procedure was updated to read the output
  and input file paths from the command line.
  The CMakeLists are now updated to account for this
* Also the Terminal output has changed slightly. The conservation law
  scripts are updated and a bug in the NB conservation (where spectators
  where neglected) is fixed.

Fixes #5.