### PR TITLE
Schaefer/update to python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ function(run_one_energy
         )
 
     add_custom_command(OUTPUT ${Hydro_lifetime_list}
-            COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/get_hydro_endtime.py"
+            COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/get_hydro_endtime.py"
                     "--Hydro_Info" "${results_folder}/${i}/Hydro/Terminal_Output.txt"
                     "--output_path" "${output_dir}"
             DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/get_hydro_endtime.py"
@@ -424,7 +424,7 @@ function(run_one_energy
                             "${results_folder}/v3.txt" ;
                      )
   add_custom_command(OUTPUT ${averaged_flow_spectra}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_flow.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_flow.py"
                   "--v2_files" "${results_folder}/*/Spectra/EP_v2.txt"
                   "--v3_files" "${results_folder}/*/Spectra/EP_v3.txt"
                   "--energy" "${energy}"
@@ -437,7 +437,7 @@ function(run_one_energy
   #----------------------------------------------------------------------------#
   set(averaged_endtime_files "${results_folder}/Endtime.txt")
   add_custom_command(OUTPUT ${averaged_endtime_files}
-         COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_endtimes.py"
+         COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_endtimes.py"
                  "--endtime_files" "${results_folder}/*/Hydro_Endtime.txt"
                   "--energy" "${energy}"
                   "--output_dir" "${results_folder}/Averaged_Spectra/"
@@ -527,9 +527,9 @@ function(Excitation_Funcs
   set(outputdir "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results")
   set(midY_plot "${outputdir}/midy_yield_exc_func.pdf")
   add_custom_command(OUTPUT ${midY_plot}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_excitation_functions.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_excitation_functions.py"
                   "--midyY_files" "${outputdir}/*/Averaged_Spectra/midyY.txt"
-                  "--v2_files" "${outputdir}/*/Averaged_Spectra/v2.txt"
+                  "--v2_files" "${outputdir}/*/Averaged_Spectra/v2spectra.txt"
                   "--meanpT_files" "${outputdir}/*/Averaged_Spectra/meanpT.txt"
                   "--output_dir" "${outputdir}/"
           DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_excitation_functions.py"
@@ -545,7 +545,7 @@ function(Integrated_vn
   set(outputdir "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results")
   set(int_vn_plot "${outputdir}/int_vn.pdf")
   add_custom_command(OUTPUT ${int_vn_plot}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_int_vn.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_int_vn.py"
                   "--vn_files" "${outputdir}/*/Averaged_Spectra/int_vn.txt"
                   "--output_dir" "${outputdir}/"
           DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_int_vn.py"
@@ -561,7 +561,7 @@ function(Hydro_Lifetimes
   set(outputdir "${CMAKE_CURRENT_BINARY_DIR}/Hybrid_Results")
   set(lifetime_file "${outputdir}/hydro_lifetime.txt")
   add_custom_command(OUTPUT ${lifetime_file}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/assemble_endtimes.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/assemble_endtimes.py"
                   "--endtime_files" "${outputdir}/*/Averaged_Spectra/Endtime.txt"
                   "--output_dir" "${outputdir}/"
           DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/assemble_endtimes.py"
@@ -645,7 +645,7 @@ function(run_custom_hybrid
     #----------------------------------------------------------------------------#
     # create input file with correct paths for vHLLE
     add_custom_command(OUTPUT "${vhlle_updated_config}"
-    COMMAND "python" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_vhlle_config.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_vhlle_config.py"
             "--vhlle_config" "${vhlle_default_config}"
             "--smash_ic" "${smash_IC_file}"
             "--output_file" "${vhlle_updated_config}"
@@ -675,7 +675,7 @@ function(run_custom_hybrid
     # create input file with correct paths for sampler
     set(N_events_afterburner "1000")
     add_custom_command(OUTPUT "${sampler_updated_config}"
-    COMMAND "python" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_sampler_config.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_sampler_config.py"
             "--sampler_config" "${sampler_default_config}"
             "--vhlle_config" "${vhlle_updated_config}"
             "--output_file" "${sampler_updated_config}"
@@ -703,7 +703,7 @@ function(run_custom_hybrid
     # Add spectators to particle list and rename it to be in accordance
     # with SMASH list modus input format
     add_custom_command(OUTPUT ${full_particle_list}
-    COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/add_spectators.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/add_spectators.py"
                       "--sampled_particle_list" "${sampler_dir}/particle_lists.oscar"
                       "--initial_particle_list" "${smash_IC_oscar}"
                       "--output_file" "${full_particle_list}"
@@ -751,7 +751,7 @@ function(run_custom_hybrid
 
     # Perform analysis
     add_custom_command(OUTPUT ${analysis_outputs}
-            COMMAND "python2" "${SMASH_ANALYSIS_PATH}/test/energy_scan/mult_and_spectra.py"
+            COMMAND "python3" "${SMASH_ANALYSIS_PATH}/test/energy_scan/mult_and_spectra.py"
                     "--output_files" ${analysis_outputs}
                     "--input_files" "${final_particle_list}"
             COMMENT "Analyzing spectra for ${system} @ ${energy} GeV (${i}/${num_runs})."
@@ -780,7 +780,7 @@ function(run_custom_hybrid
 
     # Perform plotting
     add_custom_command(OUTPUT ${plots}
-            COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
+            COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
                     "--input_files" "${results_folder}/${i}/Spectra/*.txt"
                     "--Nevents" "${N_events_afterburner}"
             COMMENT "Plotting spectra for custom hybrid run."
@@ -797,7 +797,7 @@ function(run_custom_hybrid
                        "${results_folder}/dNdy.txt"
                      )
   add_custom_command(OUTPUT ${averaged_spectra}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_spectra.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_spectra.py"
                   "--smash_ana_dir" "${SMASH_ANALYSIS_PATH}"
                   "--pT_files" "${results_folder}/*/Spectra/ptspectra.txt"
                   "--mT_files" "${results_folder}/*/Spectra/mtspectra.txt"
@@ -819,7 +819,7 @@ function(run_custom_hybrid
 
   # Perform plotting of averaged quantities
   add_custom_command(OUTPUT ${averaged_plots}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
                   "--input_files" "${results_folder}/Averaged_Spectra/*.txt"
                   "--Nevents" "${N_events_afterburner}"
                   "--average" "True"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.5.1)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(FindPythonModules)
 
-find_package(PythonInterp 2.7 REQUIRED)
-find_package(PythonLibs 2.7)
+find_package(PythonInterp 3.6 REQUIRED)
+find_package(PythonLibs 3.6)
 
 find_python_module(numpy VERSION 1.8.2 REQUIRED)
 find_python_module(matplotlib VERSION 1.3.1 REQUIRED)
@@ -169,7 +169,7 @@ function(run_one_energy
     #----------------------------------------------------------------------------#
     # create input file with correct paths for vHLLE
     add_custom_command(OUTPUT "${vhlle_updated_config}"
-    COMMAND "python" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_vhlle_config.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_vhlle_config.py"
             "--vhlle_config" "${vhlle_default_config}"
             "--smash_ic" "${smash_IC_file}"
             "--output_file" "${vhlle_updated_config}"
@@ -200,7 +200,7 @@ function(run_one_energy
     # create input file with correct paths for sampler
     set(N_events_afterburner "1000")
     add_custom_command(OUTPUT "${sampler_updated_config}"
-    COMMAND "python" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_sampler_config.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/create_sampler_config.py"
             "--sampler_config" "${sampler_default_config}"
             "--vhlle_config" "${vhlle_updated_config}"
             "--output_file" "${sampler_updated_config}"
@@ -227,7 +227,7 @@ function(run_one_energy
     # Add spectators to particle list and rename it to be in accordance
     # with SMASH list modus input format
     add_custom_command(OUTPUT ${full_particle_list}
-    COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/add_spectators.py"
+    COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/add_spectators.py"
                       "--sampled_particle_list" "${sampler_dir}/particle_lists.oscar"
                       "--initial_particle_list" "${smash_IC_oscar}"
                       "--output_file" "${full_particle_list}"
@@ -274,7 +274,7 @@ function(run_one_energy
 
     # Perform analysis
     add_custom_command(OUTPUT ${analysis_outputs}
-            COMMAND "python2" "${SMASH_ANALYSIS_PATH}/test/energy_scan/mult_and_spectra.py"
+            COMMAND "python3" "${SMASH_ANALYSIS_PATH}/test/energy_scan/mult_and_spectra.py"
                     "--output_files" ${analysis_outputs}
                     "--input_files" "${final_particle_list}"
             COMMENT "Analyzing spectra for ${system} @ ${energy} GeV (${i}/${num_runs})."
@@ -303,7 +303,7 @@ function(run_one_energy
 
     # Perform plotting
     add_custom_command(OUTPUT ${plots}
-            COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
+            COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
                     "--input_files" "${results_folder}/${i}/Spectra/*.txt"
                     "--energy" "${energy}"
                     "--system" "${system}"
@@ -326,7 +326,7 @@ function(run_one_energy
     list(APPEND all_multiplicity_plots ${Mult_plot})
     list(APPEND all_lifetime_lists ${Hydro_lifetime_list})
     add_custom_command(OUTPUT ${E_cons_plot}
-            COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/check_conservation.py"
+            COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/check_conservation.py"
                     "--SMASH_IC" "${smash_IC_oscar}"
                     "--Hydro_Info" "${results_folder}/${i}/Hydro/Terminal_Output.txt"
                     "--Sampler" "${full_particle_list}"
@@ -339,7 +339,7 @@ function(run_one_energy
         )
 
     add_custom_command(OUTPUT ${Mult_plot}
-            COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/check_multiplicities.py"
+            COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/check_multiplicities.py"
                     "--Freezeout_Surface" "${vhlle_freezeout_hypersurface}"
                     "--Sampler" "${sampled_particle_list}"
                     "--output_path" "${output_dir}"
@@ -404,7 +404,7 @@ function(run_one_energy
                        "${results_folder}/dNdy.txt"
                      )
   add_custom_command(OUTPUT ${averaged_spectra}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_spectra.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/average_spectra.py"
                   "--smash_ana_dir" "${SMASH_ANALYSIS_PATH}"
                   "--pT_files" "${results_folder}/*/Spectra/ptspectra.txt"
                   "--mT_files" "${results_folder}/*/Spectra/mtspectra.txt"
@@ -453,7 +453,7 @@ function(run_one_energy
 
   # Perform plotting of averaged quantities
   add_custom_command(OUTPUT ${averaged_plots}
-          COMMAND "python2" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
+          COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/python_scripts/plot_spectra.py"
                   "--input_files" "${results_folder}/Averaged_Spectra/*.txt"
                   "--energy" "${energy}"
                   "--system" "${system}"

--- a/cmake/FindPythonModules.cmake
+++ b/cmake/FindPythonModules.cmake
@@ -1,54 +1,20 @@
 function(find_python_module module)
-    string(TOUPPER ${module} module_upper)
-    set(options REQUIRED)
-    set(oneValueArgs VERSION)
-    cmake_parse_arguments(FIND_PY_${module_upper} "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    if(${FIND_PY_${module_upper}_REQUIRED})
-        set(PY_${module}_REQUIRED TRUE CACHE STRING
-            "Whether Python module ${module} is required")
+  string(TOUPPER ${module} module_upper)
+  if(NOT PY_${module_upper})
+    if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+      set(${module}_FIND_REQUIRED TRUE)
     endif()
-    if(NOT PY_${module_upper}_FOUND)
-        # A module's location is usually a directory, but for binary modules
-        # it's a .so file.
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-            "import re, ${module}; print re.compile('/__init__.py.*').sub('',${module}.__file__)"
-            RESULT_VARIABLE status
-            OUTPUT_VARIABLE location
-            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if(NOT status)
-            set(PY_${module_upper}_FOUND ${location} CACHE STRING
-                "Location of Python module ${module}")
-            execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-                "import re, ${module}; print re.compile('/__init__.py.*').sub('',${module}.__version__)"
-                OUTPUT_VARIABLE version
-                ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-            set(PY_${module_upper}_VERSION ${version} CACHE STRING
-                "Version of Python module ${module}")
-            if(FIND_PY_${module_upper}_VERSION)
-                if(${version} VERSION_LESS ${FIND_PY_${module_upper}_VERSION})
-                    message(SEND_ERROR "Found Python module ${module} version ${version}, but at least version ${FIND_PY_${module_upper}_VERSION} required!")
-                else()
-                    if(NOT FIND_PY_${module_upper}_REQUIRED)
-                        set(optionally "optionally ")
-                    else()
-                        set(optionally "")
-                    endif()
-                    message(STATUS "Found Python module ${module} version ${version} (version ${FIND_PY_${module_upper}_VERSION} ${optionally}required).")
-                endif()
-            else()
-                if(FIND_PY_${module_upper}_REQUIRED)
-                    set(necessity "required")
-                else()
-                    set(necessity "optional")
-                endif()
-                message(STATUS "Found ${necessity} Python module ${module}.")
-            endif()
-        else()
-            if(FIND_PY_${module_upper}_REQUIRED)
-                message(SEND_ERROR "Required python module ${module} NOT found.")
-            else()
-                message(STATUS "Optional python module ${module} NOT found.")
-            endif()
-        endif()
-    endif()
-endfunction()
+    # A module's location is usually a directory, but for binary modules
+    # it's a .so file.
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+      "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+      RESULT_VARIABLE _${module}_status
+      OUTPUT_VARIABLE _${module}_location
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _${module}_status)
+      set(PY_${module_upper} ${_${module}_location} CACHE STRING
+        "Location of Python module ${module}")
+    endif(NOT _${module}_status)
+  endif(NOT PY_${module_upper})
+  find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
+endfunction(find_python_module)

--- a/python_scripts/average_flow.py
+++ b/python_scripts/average_flow.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 def get_average(obs):
     if obs == 'v2': files = args.v2_files
     elif obs == 'v3': files = args.v3_files
-    else: print 'Observable not known'
+    else: print ('Observable not known')
 
     full_data = []
     for file in files:
@@ -31,7 +31,7 @@ def get_average(obs):
 def average_integrated_vn(obs):
     if obs == 'v2': files = args.v2_files
     elif obs == 'v3': files = args.v3_files
-    else: print 'Observable not known'
+    else: print ('Observable not known')
 
     int_vn_list = []
     for file in files:
@@ -84,8 +84,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if (len(args.v2_files) != len(args.v3_files)):
-        print 'Loaded ' + str(len(args.v2_files)) + ' v2 files, but ' + str(len(args.v3_files)) + ' v3 files.'
-    print 'Averaging over ' + str(len(args.v2_files)) + ' events.'
+        print ('Loaded ' + str(len(args.v2_files)) + ' v2 files, but ' + str(len(args.v3_files)) + ' v3 files.')
+    print ('Averaging over ' + str(len(args.v2_files)) + ' events.')
 
     mean_v2, error_v2 = get_average('v2')
     mean_v3, error_v3 = get_average('v3')

--- a/python_scripts/average_spectra.py
+++ b/python_scripts/average_spectra.py
@@ -17,7 +17,7 @@ def get_average(obs):
     elif obs == 'v2': files = args.v2_files
     elif obs == 'midyY': files = args.midyY_files
     elif obs == 'meanpT': files = args.meanpT_files
-    else: print 'Observable not known'
+    else: print ('Observable not known')
 
     full_data = []
     for file in files:
@@ -46,7 +46,9 @@ def print_to_file(mean, error, obs):
     ptbins = linecache.getline(args.smash_ana_dir + '/test/energy_scan/mult_and_spectra.py', 22)
     midybins = linecache.getline(args.smash_ana_dir + '/test/energy_scan/mult_and_spectra.py', 23)
     if midybins.split()[0] != 'midrapidity_cut' or mtbins.split()[0] != 'mtbins' or ptbins.split()[0] != 'ptbins' or ybins.split()[0] != 'ybins':
-        print 'Problem in determination of bin width. The smash-analysis script \'smash-analysis/test/energy_scan/mult_and_spectra.py\' was modified after this file was created. Please check and update accordingly.'
+        print ('Problem in determination of bin width. '
+               'The smash-analysis script \'smash-analysis/test/energy_scan/mult_and_spectra.py\' '
+               'was modified after this file was created. Please check and update accordingly.')
 
     mtbin_edges = eval(mtbins.split('=')[1][:-2])
     ptbin_edges = eval(ptbins.split('=')[1][:-2])
@@ -54,7 +56,8 @@ def print_to_file(mean, error, obs):
     midy_bin_width = 2.0 * float(midybins.split()[-1].split(')')[0])
 
     # create files and write content
-    file = open(args.output_dir + obs + '.txt', 'w')
+    if obs == 'v2': file = open(args.output_dir + obs + 'spectra.txt', 'w')
+    else: file = open(args.output_dir + obs + '.txt', 'w')
     if obs in ['midyY', 'meanpT']: file.write('# ' + obs + ' spectra, already divided by events\n')
     else: file.write('# ' + obs + ' spectra, already divided by bin width and events\n')
     if obs == 'v2': file.write('# pT_bin_center 211 211_error -211 -211_error 111 111_error 321 321_error -321 -321_error 2212 2212_error -2212 -2212_error 3122 3122_error -3122 -3122_error\n')
@@ -117,8 +120,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if (len(args.pT_files) != len(args.mT_files)) or (len(args.pT_files) != len(args.y_files)):
-        print 'Loaded ' + str(len(args.pT_files)) + ' pT files, but ' + str(len(args.mT_files)) + ' mT files and ' + str(len(args.y_files)) + '  files.'
-    print 'Averaging over ' + str(len(args.pT_files)) + ' events.'
+        print ('Loaded ' + str(len(args.pT_files)) + ' pT files, but ' + str(len(args.mT_files)) + ' mT files and ' + str(len(args.y_files)) + '  files.')
+    print ('Averaging over ' + str(len(args.pT_files)) + ' events.')
 
     mean_pT, error_pT = get_average('pT')
     mean_mT, error_mT = get_average('mT')

--- a/python_scripts/check_conservation.py
+++ b/python_scripts/check_conservation.py
@@ -125,6 +125,7 @@ def energy_from_hydro(file):
         if line.startswith('timestep'): continue
         if line.startswith('####'): continue
         if line.startswith('       tau'): continue
+        if line.startswith('mkdir returns:'): continue
         # Find values before grid resize
         if line.startswith('grid'):
             NB_before = baryon_number
@@ -181,7 +182,7 @@ def plotting_E_conservation(IC_energy, Specs_energy, hydro_energy, Sampler_energ
     plt.plot(x, [hydro_energy + Specs_energy] * Nevents, label = 'Hydro: Energy through Surface + Energy from Spectators', color = 'green', lw = 2)
     plt.plot(x, [np.mean(Sampler_energy)]*Nevents, label = 'Sampler: Mean Energy + Energy from Spectators', color = 'midnightblue', lw = 2)
     plt.plot(x, [Final_State_energy]*Nevents, label = 'SMASH: Final State Energy', color = 'orange', lw = 2, ls = '--')
-    plt.legend(title = r'$\Delta$E = ' + str(round(100*(np.mean(Final_State_energy)/IC_energy - 1),2)) + ' %', loc = 'lower center')
+    plt.legend(title = r'$\Delta$E = ' + str(round(float(100*(Final_State_energy/IC_energy - 1)),2)) + ' %', loc = 'lower center')
     plt.title(system + r' @ $\mathbf{\sqrt{s}}$ = ' + energy + ' GeV', fontweight = 'bold')
     plt.xlim(0,Nevents + 1)
     plt.xlabel('Event')
@@ -204,7 +205,7 @@ def plotting_NB_conservation(IC_NB, Specs_NB, hydro_NB, Sampler_NB, Final_State_
     plt.plot(x, [Specs_NB + hydro_NB]*Nevents, label = r'Hydro: N$_\mathsf{B - \bar{B}}$', color = 'green', lw = 2)
     plt.plot(x, [np.mean(Sampler_NB)]*Nevents, label = r'Sampler: Mean N$_\mathsf{B - \bar{B}}$', color = 'midnightblue', lw = 2)
     plt.plot(x, [Final_State_NB]*Nevents, label = r'SMASH: Final State N$_\mathsf{B - \bar{B}}$', color = 'orange', lw = 2, ls = '--')
-    plt.legend(title = r'$\Delta$N$_\mathsf{B}$ = ' + str(round(100*(np.mean(Final_State_NB)/IC_NB - 1),2)) + ' %')
+    plt.legend(title = r'$\Delta$N$_\mathsf{B}$ = ' + str(round(float(100*(Final_State_NB/IC_NB - 1)),2)) + ' %')
     plt.title(system + r' @ $\mathbf{\sqrt{s}}$ = ' + energy + ' GeV', fontweight = 'bold')
     plt.xlim(0,Nevents + 1)
     plt.xlabel('Event')
@@ -242,13 +243,12 @@ if __name__ == '__main__':
     NB_sampler_per_Event_no_specs, E_sampler_per_Event_no_specs = energy_from_oscar(Sampler_without_specs, False)
     NB_SMASH_final_state, E_SMASH_final_state = energy_from_binary(args.SMASH_final_state)
 
-
     plotting_E_conservation(E_SMASH_IC, E_SMASH_IC_specs[0], E_hydro, E_sampler_per_Event, E_sampler_per_Event_no_specs, E_SMASH_final_state)
     plotting_NB_conservation(NB_SMASH_IC, NB_SMASH_IC_specs[0], NB_hydro, NB_sampler_per_Event, NB_SMASH_final_state)
 
-    print 'Initial SMASH energy: ' + str(E_SMASH_IC[0])
-    print 'Spectator energy: ' + str(E_SMASH_IC_specs)
-    print 'Hydro energy through surface: ' + str(E_hydro)
-    print 'Sampler energy: ' + str(np.mean(E_sampler_per_Event))
-    print 'Final SMASH energy: ' + str(E_SMASH_final_state)
-    print 'Energy gain/loss: ' + str(round(100 * ((np.mean(E_SMASH_final_state) / E_SMASH_IC) -1),2) ) + ' %'
+    print ('Initial SMASH energy: ' + str(E_SMASH_IC[0]))
+    print ('Spectator energy: ' + str(E_SMASH_IC_specs[0]))
+    print ('Hydro energy through surface: ' + str(E_hydro))
+    print ('Sampler energy: ' + str(np.mean(E_sampler_per_Event)))
+    print ('Final SMASH energy: ' + str(E_SMASH_final_state))
+    print ('Energy gain/loss: ' + str(round(100 * ((np.mean(E_SMASH_final_state) / E_SMASH_IC[0]) -1),2) ) + ' %')

--- a/python_scripts/get_hydro_endtime.py
+++ b/python_scripts/get_hydro_endtime.py
@@ -24,7 +24,6 @@ if __name__ == '__main__':
 
 
     endtime = Endtime_from_hydro(args.Hydro_Info)
-    print endtime
 
     with open(args.output_path + '/Hydro_Endtime.txt', 'w') as f:
         f.write('# endtime \n')

--- a/python_scripts/plot_excitation_functions.py
+++ b/python_scripts/plot_excitation_functions.py
@@ -23,6 +23,7 @@ def collect_data(files):
                        'errors' : {'211' : [], '-211' : [],'111' : [],'321' : [],'-321' : [],'2212' : [],'-2212' : [], '3122' : [], '-3122' : []}}
 
     for file in files:
+        if 'Custom' in file: continue
         energy = file.split('/')[-3].split('_')[1]
         if 'v2' in file:
             data = np.loadtxt(file, unpack = True)
@@ -130,7 +131,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     data_midyY = collect_data(args.midyY_files)
-    data_v2 = collect_data(args.v2_files)
+    # data_v2 = collect_data(args.v2_files)
     data_meanpT = collect_data(args.meanpT_files)
 
     write_data(data_midyY, 'Excitation_Func_midy_Yield.txt')

--- a/python_scripts/plot_int_vn.py
+++ b/python_scripts/plot_int_vn.py
@@ -28,7 +28,7 @@ def collect_data(files):
             f.readline()    # skip header
             f.readline()    # skip header
             data = f.readline().split()
-            print energy
+            print (energy)
             data_collection['energies'].append(float(data[0]))
             data_collection['values']['v2'].append(float(data[1]))
             data_collection['values']['v3'].append(float(data[3]))


### PR DESCRIPTION
Update the fully hybrid to employ python3 instead of python2. 

This branch is however rebased on schaefer/custom_smash_IC_config_12 and can hence only be merged once #17 is merged. Thus filing a draft. 

Fixes #3.