### PR TITLE
Fix energy of testcase and make it independent of custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,7 +891,7 @@ function(test_hybrid
 
     set(smash_IC_file "${results_folder}/${i}/IC/SMASH_IC.dat")
     set(smash_IC_oscar "${results_folder}/${i}/IC/SMASH_IC.oscar")
-    set(smash_IC_config "${CMAKE_CURRENT_SOURCE_DIR}/configs/smash_initial_conditions_custom.yaml")
+    set(smash_IC_config "${CMAKE_CURRENT_SOURCE_DIR}/configs/smash_initial_conditions_AuAu.yaml")
     set(vhlle_default_config "${CMAKE_CURRENT_SOURCE_DIR}/configs/vhlle_hydro")
     set(vhlle_output_dir "${results_folder}/${i}/Hydro/")
     set(vhlle_updated_config "${results_folder}/${i}/Hydro/vhlle_config")

--- a/configs/smash_initial_conditions_AuAu.yaml
+++ b/configs/smash_initial_conditions_AuAu.yaml
@@ -25,5 +25,6 @@ Modi:
             Particles: {2212: 79, 2112: 118} #Gold197
 
         Fermi_Motion: frozen
+        Sqrtsnn: 7.7
         Impact:
             Max: 2.3


### PR DESCRIPTION
The test case used the custom target template config file, which is to be modified for custom targets. It was changed to use the AuAu config file. The latter has now also the right collision energy for the test target.