### PR TITLE
Disable saving SMASH tabulations on disk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ function(run_one_energy
         "-i" "${smash_IC_config}"
         "-c" "Modi: {Collider: {Sqrtsnn: ${energy}}}"
         "-f"
+        "-n"
         ">" "${results_folder}/${i}/IC/Terminal_Output.txt"
     DEPENDS
         "${smash_IC_config}"
@@ -245,6 +246,7 @@ function(run_one_energy
         "-c" "General: { Nevents: ${N_events_afterburner} }"
         "-o" "${results_folder}/${i}/Afterburner"
         "-f"
+        "-n"
         ">" "/dev/null"
     DEPENDS
         "${smash_afterburner_config}"
@@ -632,6 +634,7 @@ function(run_custom_hybrid
         "-o" "${results_folder}/${i}/IC"
         "-i" "${smash_IC_config}"
         "-f"
+        "-n"
         ">" "${results_folder}/${i}/IC/Terminal_Output.txt"
     DEPENDS
         "${smash_IC_config}"
@@ -721,6 +724,7 @@ function(run_custom_hybrid
         "-c" "General: { Nevents: ${N_events_afterburner} }"
         "-o" "${results_folder}/${i}/Afterburner"
         "-f"
+        "-n"
         ">" "/dev/null"
     DEPENDS
         "${smash_afterburner_config}"
@@ -918,6 +922,7 @@ function(test_hybrid
         "-o" "${results_folder}/${i}/IC"
         "-i" "${smash_IC_config}"
         "-f"
+        "-n"
         ">" "${results_folder}/${i}/IC/Terminal_Output.txt"
     DEPENDS
         "${smash_IC_config}"
@@ -1008,6 +1013,7 @@ function(test_hybrid
         "-c" "General: { Nevents: ${N_events_afterburner} }"
         "-o" "${results_folder}/${i}/Afterburner"
         "-f"
+        "-n"
         ">" "/dev/null"
     DEPENDS
         "${smash_afterburner_config}"


### PR DESCRIPTION
Currently the SMASH integral tabulations are saved on disk, which improves runtime when SMASH is rerun. Due to the setup of the hybrid, there would be separate tabulations for each hydro event and both IC and afterburner, which greatly reduces this advantage. For now, saving the tabulations is disabled, which improves performance on lustre clusters as considerably less files are opened.