### PR TITLE
Update to ITP email addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,15 +4,22 @@ Anna Schäfer <aschaefer@fias.uni-frankfurt.de>
 Anna Schäfer <aschaefer@fias.uni-frankfurt.de> <36138176+akschaefer@users.noreply.github.com>
 Gabriele Inghirami <g.inghirami@gsi.de> <71900834+gabriele-inghirami@users.noreply.github.com>
 Gabriele Inghirami <g.inghirami@gsi.de> gabriele-inghirami <gabriele.inghirami@gmail.com>
-Niklas Götz <goetz@fias.uni-frankfurt.de>
-Niklas Götz <goetz@fias.uni-frankfurt.de> <ngoetz@lxbk0599.gsi.de>
-Niklas Götz <goetz@fias.uni-frankfurt.de> <goetz.niklas@googlemail.com>
-Niklas Götz <goetz@fias.uni-frankfurt.de> Niklas Goetz <goetz@fias.uni-frankfurt.de>
-Nils Saß <nsass@fias.uni-frankfurt.de>
-Nils Saß <nsass@fias.uni-frankfurt.de> <90659054+nilssass@users.noreply.github.com>
-Jan Hammelmann <hammelmann@fias.uni-frankfurt.de>
-Jan Hammelmann <hammelmann@fias.uni-frankfurt.de> <33685583+JanHammelmann@users.noreply.github.com>
-Renan Hirayama <hirayama@fias.uni-frankfurt.de>
-Renan Hirayama <hirayama@fias.uni-frankfurt.de> RenHirayama <79031685+RenHirayama@users.noreply.github.com>
+Niklas Götz <goetz@itp.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <goetz@fias.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <goetz@users.itp.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <ngoetz@lxbk0599.gsi.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <goetz.niklas@googlemail.com>
+Niklas Götz <goetz@itp.uni-frankfurt.de> Niklas Goetz <goetz@fias.uni-frankfurt.de>
+Nils Saß <nsass@itp.uni-frankfurt.de>
+Nils Saß <nsass@itp.uni-frankfurt.de> <nsass@fias.uni-frankfurt.de>
+Nils Saß <nsass@itp.uni-frankfurt.de> <90659054+nilssass@users.noreply.github.com>
+Jan Hammelmann <hammelmann@itp.uni-frankfurt.de>
+Jan Hammelmann <hammelmann@itp.uni-frankfurt.de> <hammelmann@fias.uni-frankfurt.de>
+Jan Hammelmann <hammelmann@itp.uni-frankfurt.de> <jan.hammelmann@live.de>
+Jan Hammelmann <hammelmann@itp.uni-frankfurt.de> <33685583+JanHammelmann@users.noreply.github.com>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de> <hirayama@fias.uni-frankfurt.de>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de> RenHirayama <79031685+RenHirayama@users.noreply.github.com>
+Robin Sattler <sattler@itp.uni-frankfurt.de>
 Zuzana Paulinyova <zuzana.paulinyova@upjs.sk>
-Zuzana Paulinyova <zuzana.paulinyova@upjs.sk> zpauliny <103072930+zpauliny@users.noreply.github.com>
+Zuzana Paulinyova <zuzana.paulinyova@upjs.sk> <103072930+zpauliny@users.noreply.github.com>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,12 +2,11 @@
 
 | Name  | E-mail |
 | :---: | :----: |
-| Alessandro Sciarra | asciarra@fias.uni-frankfurt.de   |
+| Alessandro Sciarra | sciarra@itp.uni-frankfurt.de     |
 | Gabriele Inghirami | g.inghirami@gsi.de               |
-| Jan Hammelmann     | hammelmann@fias.uni-frankfurt.de |
-| Niklas Götz        | goetz@fias.uni-frankfurt.de      |
-| Nils Saß           | nsass@fias.uni-frankfurt.de      |
-| Renan Hirayama     | hirayama@fias.uni-frankfurt.de   |
+| Niklas Götz        | goetz@itp.uni-frankfurt.de       |
+| Nils Saß           | nsass@itp.uni-frankfurt.de       |
+| Renan Hirayama     | hirayama@itp.uni-frankfurt.de    |
 | Zuzana Paulinyova  | zuzana.paulinyova@upjs.sk        |
 
 ## Past developers
@@ -16,4 +15,5 @@ Please, note that the e-mail address of past developers might not be active any 
 
 |  Name  | E-mail |
 | :----: | :----: |
-| Anna Schäfer | aschaefer@fias.uni-frankfurt.de |
+| Anna Schäfer       | aschaefer@fias.uni-frankfurt.de  |
+| Jan Hammelmann     | hammelmann@itp.uni-frankfurt.de |


### PR DESCRIPTION
I noticed that the handler still uses the fias emails in the AUTHOR.md file and updated this. Additionally, I moved Jan Hammelmann to "Past developers". @AxelKrypton, could you double check the updated mail addresses?

I also updated the .mailmap file to the itp email addresses and added a few addresses that were missing in it.