### PR TITLE
Modify IC base configuration file and predef configs

### DIFF
--- a/configs/predef_configs/config_AuAu_200.0.yaml
+++ b/configs/predef_configs/config_AuAu_200.0.yaml
@@ -25,3 +25,8 @@ Sampler:
 
 Afterburner:
     Executable: /path/to/smash
+    Software_keys:
+        Collision_Term:
+            Strings: True
+            String_Parameters:
+                Use_Monash_Tune: True

--- a/configs/predef_configs/config_PbPb_2760.0.yaml
+++ b/configs/predef_configs/config_PbPb_2760.0.yaml
@@ -25,3 +25,8 @@ Sampler:
 
 Afterburner:
     Executable: /path/to/smash
+    Software_keys:
+        Collision_Term:
+            Strings: True
+            String_Parameters:
+                Use_Monash_Tune: True

--- a/configs/predef_configs/config_PbPb_5020.0.yaml
+++ b/configs/predef_configs/config_PbPb_5020.0.yaml
@@ -25,3 +25,8 @@ Sampler:
 
 Afterburner:
     Executable: /path/to/smash
+    Software_keys:
+        Collision_Term:
+            Strings: True
+            String_Parameters:
+                Use_Monash_Tune: True

--- a/configs/smash_afterburner.yaml
+++ b/configs/smash_afterburner.yaml
@@ -9,6 +9,11 @@ General:
     Randomseed:    -1
     Nevents:       1000
 
+Collision_Term:
+    Strings: True
+    String_Parameters:
+        Use_Monash_Tune: False
+
 Output:
     Particles:
         Format:          ["Oscar2013"]

--- a/configs/smash_initial_conditions.yaml
+++ b/configs/smash_initial_conditions.yaml
@@ -26,3 +26,6 @@ Modi:
         Fermi_Motion: frozen
         Impact:
             Max: 2.3
+        
+        Initial_Conditions:
+            Type: "Constant_Tau"


### PR DESCRIPTION
This PR has two small changes: 
- new syntax for initial conditions in SMASH IC config is needed (for SMASH 3.2)
- turn on Monash tune in Afterburner stage at highest energies for consistency (needed to add this key to afterburner base config)