### PR TITLE
Add more instructive sentence to failure output

### DIFF
--- a/bash/common_functionality.bash
+++ b/bash/common_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -60,7 +60,7 @@ function Separate_Terminal_Output_For()
 function Report_About_Software_Failure_For()
 {
     exit_code=${HYBRID_fatal_software_failed} Print_Fatal_And_Exit \
-        '\n' --emph "$1" ' run failed.'
+        '\n' --emph "$1" ' run failed (look at its output files for more information).'
 }
 
 function Ensure_Input_File_Exists_And_Alert_If_Unfinished()

--- a/tests/unit_tests_Hydro_functionality.bash
+++ b/tests/unit_tests_Hydro_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -178,7 +178,6 @@ function Unit_Test__Hydro-test-run-software()
         Print_Error 'The terminal output has not the expected content.'
         return 1
     fi
-
 }
 
 function Clean_Tests_Environment_For_Following_Test__Hydro-test-run-software()


### PR DESCRIPTION
This closes #41 IMO. It is a minor improvement, but the only one I believe that we should undertake.

Of course, we should decide whether we want to ship the container that we built for internal use and, if so, we should then mention in the documentation. I will open an issue to discuss this further.