### PR TITLE
Remove obsolete smash sampler config keys and improve sampler unit test functions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@
 | Niklas Götz        | goetz@itp.uni-frankfurt.de       |
 | Nils Saß           | nsass@itp.uni-frankfurt.de       |
 | Renan Hirayama     | hirayama@itp.uni-frankfurt.de    |
+| Robin Sattler      | sattler@itp.uni-frankfurt.de     |
 | Zuzana Paulinyova  | zuzana.paulinyova@upjs.sk        |
 
 ## Past developers

--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -88,7 +88,7 @@ function Validate_Configuration_File_Of_SMASH()
                 ;;
             number_of_events)
                 if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
-                    Print_Error 'Found not-integer value ' --emph "${value}" \
+                    Print_Error 'Found non-integer value ' --emph "${value}" \
                         ' for ' --emph "${key}" ' key.'
                     return 1
                 fi

--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -38,13 +38,9 @@ function Validate_Configuration_File_Of_SMASH()
         'surface'
         'spectra_dir'
         'number_of_events'
-        'rescatter'
-        'weakContribution'
         'shear'
         'bulk'
         'ecrit'
-        'Nbins'
-        'q_max'
         'cs2'
         'ratio_pressure_energydensity'
     )
@@ -83,14 +79,14 @@ function Validate_Configuration_File_Of_SMASH()
                 fi
                 ((keys_to_be_found--))
                 ;;
-            rescatter | weakContribution | shear | bulk)
+            shear | bulk)
                 if [[ ! "${value}" =~ ^[01]$ ]]; then
                     Print_Error 'Key ' --emph "${key}" ' must be either ' \
                         --emph '0' ' or ' --emph '1' '.'
                     return 1
                 fi
                 ;;
-            number_of_events | Nbins)
+            number_of_events)
                 if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
                     Print_Error 'Found not-integer value ' --emph "${value}" \
                         ' for ' --emph "${key}" ' key.'

--- a/configs/hadron_sampler
+++ b/configs/hadron_sampler
@@ -1,7 +1,6 @@
 surface          =DEFAULT=
 spectra_dir      =DEFAULT=
 number_of_events 1000
-weakContribution 0
 shear            1
 bulk             0
 ecrit            0.5

--- a/configs/hadron_sampler
+++ b/configs/hadron_sampler
@@ -1,6 +1,8 @@
-surface          =DEFAULT=
-spectra_dir      =DEFAULT=
-number_of_events 1000
-shear            1
-bulk             0
-ecrit            0.5
+surface                       =DEFAULT=
+spectra_dir                   =DEFAULT=
+number_of_events              1000
+ecrit                         0.5
+bulk                          0
+shear                         0
+cs2                           0.15
+ratio_pressure_energydensity  0.15

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -219,12 +219,8 @@ function Unit_Test__Sampler-validate-config-file()
     local wrong_key_value
     for wrong_key_value in \
         'number_of_events 3.14' \
-        'rescatter 3..14' \
-        'weakContribution false' \
         'shear true' \
-        'ecrit +-1' \
-        'Nbins -100' \
-        'q_max 1.6'; do
+        'ecrit +-1'; do
         printf '%s\n' "${wrong_key_value}" > "${HYBRID_software_configuration_file[Sampler]}"
         Call_Codebase_Function_In_Subshell __static__Is_Sampler_Config_Valid &> /dev/null
         if [[ $? -eq 0 ]]; then

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -30,13 +30,13 @@ function __static__Do_Preliminary_Sampler_Setup_Operations()
     touch "${HYBRID_configuration_file}"
 }
 
-function Make_Test_Preliminary_Operations__Sampler-create-input-file()
+function Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH()
 {
     __static__Do_Preliminary_Sampler_Setup_Operations
     Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
 }
 
-function Unit_Test__Sampler-create-input-file()
+function Unit_Test__Sampler-create-input-file-SMASH()
 {
     HYBRID_module[Sampler]='SMASH'
     mkdir -p "${HYBRID_software_output_directory[Hydro]}"
@@ -67,7 +67,7 @@ function Unit_Test__Sampler-create-input-file()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file()
+function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH()
 {
     rm -r "${HYBRID_output_directory}"
 }
@@ -103,12 +103,12 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-w
     rm -r "${HYBRID_output_directory}"
 }
 
-function Make_Test_Preliminary_Operations__Sampler-check-all-input()
+function Make_Test_Preliminary_Operations__Sampler-check-all-input-SMASH()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
 }
 
-function Unit_Test__Sampler-check-all-input()
+function Unit_Test__Sampler-check-all-input-SMASH()
 {
     HYBRID_module[Sampler]='SMASH'
     Call_Codebase_Function_In_Subshell Ensure_All_Needed_Input_Exists_Sampler &> /dev/null
@@ -144,17 +144,17 @@ function Unit_Test__Sampler-check-all-input()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-check-all-input()
+function Clean_Tests_Environment_For_Following_Test__Sampler-check-all-input-SMASH()
 {
-    rm -r "${HYBRID_output_directory}"
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
-function Make_Test_Preliminary_Operations__Sampler-validate-config-file()
+function Make_Test_Preliminary_Operations__Sampler-validate-config-file-SMASH()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
 }
 
-function Unit_Test__Sampler-validate-config-file()
+function Unit_Test__Sampler-validate-config-file-SMASH()
 {
     HYBRID_module[Sampler]='SMASH'
     mkdir -p "${HYBRID_software_output_directory[Sampler]}"
@@ -239,14 +239,14 @@ function Unit_Test__Sampler-validate-config-file()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-validate-config-file()
+function Clean_Tests_Environment_For_Following_Test__Sampler-validate-config-file-SMASH()
 {
-    rm -r "${HYBRID_output_directory}"
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
 function Make_Test_Preliminary_Operations__Sampler-validate-config-file-FIST()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
     HYBRID_module[Sampler]='FIST'
     touch "${HYBRID_fist_module[Particle_file]}" "${HYBRID_fist_module[Decays_file]}"
 }
@@ -363,7 +363,7 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-validate-config-fil
     rm -r "${HYBRID_output_directory}"
 }
 
-function Make_Test_Preliminary_Operations__Sampler-config-consistent-with-hydro()
+function Make_Test_Preliminary_Operations__Sampler-config-consistent-with-hydro-SMASH()
 {
     __static__Do_Preliminary_Sampler_Setup_Operations
     HYBRID_given_software_sections+=('Hydro')
@@ -371,7 +371,7 @@ function Make_Test_Preliminary_Operations__Sampler-config-consistent-with-hydro(
     Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
 }
 
-function Unit_Test__Sampler-config-consistent-with-hydro()
+function Unit_Test__Sampler-config-consistent-with-hydro-SMASH()
 {
     HYBRID_module[Sampler]='SMASH'
     mkdir -p "${HYBRID_software_output_directory[Hydro]}"
@@ -396,17 +396,17 @@ function Unit_Test__Sampler-config-consistent-with-hydro()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-config-consistent-with-hydro()
+function Clean_Tests_Environment_For_Following_Test__Sampler-config-consistent-with-hydro-SMASH()
 {
-    rm -r "${HYBRID_output_directory}"
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
-function Make_Test_Preliminary_Operations__Sampler-test-run-software()
+function Make_Test_Preliminary_Operations__Sampler-test-run-software-SMASH()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
 }
 
-function Unit_Test__Sampler-test-run-software()
+function Unit_Test__Sampler-test-run-software-SMASH()
 {
     HYBRID_module[Sampler]='SMASH'
     mkdir -p "${HYBRID_software_output_directory[Sampler]}"
@@ -425,14 +425,14 @@ function Unit_Test__Sampler-test-run-software()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-test-run-software()
+function Clean_Tests_Environment_For_Following_Test__Sampler-test-run-software-SMASH()
 {
-    Clean_Tests_Environment_For_Following_Test__Sampler-check-all-input
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
 function Make_Test_Preliminary_Operations__Sampler-test-run-software_FIST()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
     HYBRID_module[Sampler]='FIST'
     touch "${HYBRID_fist_module[Particle_file]}" "${HYBRID_fist_module[Decays_file]}"
 }
@@ -458,7 +458,7 @@ function Unit_Test__Sampler-test-run-software_FIST()
 
 function Clean_Tests_Environment_For_Following_Test__Sampler-test-run-software-FIST()
 {
-    Clean_Tests_Environment_For_Following_Test__Sampler-check-all-input
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
     rm "${HYBRID_fist_module[Decays_file]}"
     rm "${HYBRID_fist_module[Particle_file]}"
     rm -r "${HYBRID_output_directory}"

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -72,7 +72,7 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-S
     rm -r "${HYBRID_output_directory}"
 }
 
-function Make_Test_Preliminary_Operations__Sampler-create-input-file-with-FIST()
+function Make_Test_Preliminary_Operations__Sampler-create-input-file-FIST()
 {
     __static__Do_Preliminary_Sampler_Setup_Operations
     HYBRID_module[Sampler]='FIST'
@@ -81,7 +81,7 @@ function Make_Test_Preliminary_Operations__Sampler-create-input-file-with-FIST()
 
 }
 
-function Unit_Test__Sampler-create-input-file-with-FIST()
+function Unit_Test__Sampler-create-input-file-FIST()
 {
     HYBRID_module[Sampler]='FIST'
     mkdir -p "${HYBRID_software_output_directory[Hydro]}"
@@ -96,7 +96,7 @@ function Unit_Test__Sampler-create-input-file-with-FIST()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-with-FIST()
+function Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-FIST()
 {
     rm "${HYBRID_fist_module[Decays_file]}"
     rm "${HYBRID_fist_module[Particle_file]}"
@@ -246,9 +246,7 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-validate-config-fil
 
 function Make_Test_Preliminary_Operations__Sampler-validate-config-file-FIST()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
-    HYBRID_module[Sampler]='FIST'
-    touch "${HYBRID_fist_module[Particle_file]}" "${HYBRID_fist_module[Decays_file]}"
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-FIST
 }
 
 function Unit_Test__Sampler-validate-config-file-FIST()
@@ -358,9 +356,7 @@ function Unit_Test__Sampler-validate-config-file-FIST()
 
 function Clean_Tests_Environment_For_Following_Test__Sampler-validate-config-file-FIST()
 {
-    rm "${HYBRID_fist_module[Decays_file]}"
-    rm "${HYBRID_fist_module[Particle_file]}"
-    rm -r "${HYBRID_output_directory}"
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-FIST
 }
 
 function Make_Test_Preliminary_Operations__Sampler-config-consistent-with-hydro-SMASH()
@@ -430,14 +426,12 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-test-run-software-S
     Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
-function Make_Test_Preliminary_Operations__Sampler-test-run-software_FIST()
+function Make_Test_Preliminary_Operations__Sampler-test-run-software-FIST()
 {
-    Make_Test_Preliminary_Operations__Sampler-create-input-file-SMASH
-    HYBRID_module[Sampler]='FIST'
-    touch "${HYBRID_fist_module[Particle_file]}" "${HYBRID_fist_module[Decays_file]}"
+    Make_Test_Preliminary_Operations__Sampler-create-input-file-FIST
 }
 
-function Unit_Test__Sampler-test-run-software_FIST()
+function Unit_Test__Sampler-test-run-software-FIST()
 {
     HYBRID_module[Sampler]='FIST'
     mkdir -p "${HYBRID_software_output_directory[Sampler]}"
@@ -458,8 +452,5 @@ function Unit_Test__Sampler-test-run-software_FIST()
 
 function Clean_Tests_Environment_For_Following_Test__Sampler-test-run-software-FIST()
 {
-    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
-    rm "${HYBRID_fist_module[Decays_file]}"
-    rm "${HYBRID_fist_module[Particle_file]}"
-    rm -r "${HYBRID_output_directory}"
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-FIST
 }

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -219,8 +219,11 @@ function Unit_Test__Sampler-validate-config-file-SMASH()
     local wrong_key_value
     for wrong_key_value in \
         'number_of_events 3.14' \
+        'bulk true' \
         'shear true' \
-        'ecrit +-1'; do
+        'cs2 +-1' \
+        'ecrit +-1' \
+        'ratio_pressure_energydensity +-1'; do
         printf '%s\n' "${wrong_key_value}" > "${HYBRID_software_configuration_file[Sampler]}"
         Call_Codebase_Function_In_Subshell __static__Is_Sampler_Config_Valid &> /dev/null
         if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
This is the fix for the first stage of #52.

**What I did:**
- Remove obsolete config keys `Nbins`, `q_max`, `rescatter`, and `weakContribution` (these are not in use since before the first tag `SMASH-hadron-sampler-1.0` and hence can be safely removed from the hybrid framework).
- Add all missing sampler config keys to hadron sampler config (set to their default values).
- Renamed the unit tests relating to the SMASH-Hadron-Sampler since this was imprecise/confusing when running the tests. The FIST tests have a "-FIST" suffix, so I added a "-SMASH" suffix for the hadron sampler tests.
- Fixed some inconsistencies in the unit test functions

@NGoetz and @AxelKrypton, since this is my first (real) contribution to the handler, I'm looking forward to your feedback.