### PR TITLE
Add version comparison utility function

### DIFF
--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -102,7 +102,7 @@ function Act_And_Exit_If_User_Ran_Auxiliary_Modes()
             Print_Software_Version
             ;;&
         *help | format | version)
-            exit ${HYBRID_success_exit_code}
+            exit 0
             ;;
     esac
 }

--- a/bash/error_codes.bash
+++ b/bash/error_codes.bash
@@ -1,15 +1,15 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
 #
 #===================================================
 
-# Standard bash exit codes
-readonly HYBRID_success_exit_code=0
-readonly HYBRID_failure_exit_code=1
+# Standard bash exit codes (0 for success and 1 for generic failure) are not
+# aliased to a variable here. This is an aware decision because they are so
+# standard that hard-coding them in the codebase where needed is just fine.
 
 # Variables for exit codes (between 64 and 113)
 #   -> http://tldp.org/LDP/abs/html/exitcodes.html

--- a/bash/system_requirements.bash
+++ b/bash/system_requirements.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -18,7 +18,7 @@ function __static__Declare_System_Requirements()
 {
     Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
     if ! declare -p HYBRID_version_regex &> /dev/null; then
-        readonly HYBRID_version_regex='[0-9](.[0-9]+)*'
+        readonly HYBRID_version_regex='[0-9]+(.[0-9]+)*'
         readonly HYBRID_python_requirements_file="${HYBRID_top_level_path}/python/requirements.txt"
         readonly HYBRID_python_test_requirement_tool="${HYBRID_top_level_path}/python/test_requirement.py"
         declare -rgA HYBRID_versions_requirements=(

--- a/bash/utility_functions.bash
+++ b/bash/utility_functions.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -59,6 +59,99 @@ function Element_In_Array_Matches()
         [[ "${element}" =~ $1 ]] && return 0
     done
     return 1
+}
+
+: << 'DOCSTRING'
+--8<-- [start:Is_Version-desc]
+Compare two versions. This function takes two version numbers as first and third
+arguments and a comparison operator among `>`, `<`, `>=`, `<=`, `=`, `==`, `!=`.
+Alternatively to the operator, you can use the test comparison options and namely
+`-gt`, `-lt`, `-ge`, `-le`, `-eq` or `-ne`, respectively.
+The function returns 0 if the comparison is true, 1 otherwise.
+!!! warning "Mind redirection"
+    If you use this function with a comparison operator containing the `>` or
+    the `<` symbol, you need to either quote it or backslash-escape it, otherwise
+    it will be interpreted as redirection.
+--8<-- [end:Is_Version-desc]
+--8<-- [start:Is_Version-ex]
+if Is_Version '3.01' \>= '3.1.0'; then
+    # This if is entered
+fi
+if Is_Version '1.42' '>' '1.42.0.0.1'; then
+    # This if is entered
+fi
+if Is_Version '1.42' -gt '1.42.0.0.1'; then
+    # This if is entered
+fi
+--8<-- [end:Is_Version-ex]
+DOCSTRING
+# NOTE: This function will be used when checking system requirements and hence, we
+#       want to use Bash only here without using external commands (sort, sed, etc.).
+function Is_Version()
+{
+    local -r \
+        version_regex='^[0-9]+(.[0-9]+)*$' \
+        valid_operators=('>' '<' '>=' '<=' '=' '==' '!=' '-gt' '-lt' '-ge' '-le' '-eq' '-ne')
+    if [[ $# -ne 3 ]]; then
+        Print_Internal_And_Exit \
+            'Function ' --emph "${FUNCNAME}" \
+            ' called with wrong number of arguments (' --emph "$#" ' != 3)'
+    elif [[ ! $1 =~ ${version_regex} ]]; then
+        Print_Internal_And_Exit \
+            'Function ' --emph "${FUNCNAME}" \
+            ' called with invalid first argument ' --emph "$1" ' (not a version number).'
+    elif ! Element_In_Array_Equals_To "$2" "${valid_operators[@]}"; then
+        Print_Internal_And_Exit \
+            'Function ' --emph "${FUNCNAME}" \
+            ' called with invalid operator ' --emph "$2" '.'
+    elif [[ ! $3 =~ ${version_regex} ]]; then
+        Print_Internal_And_Exit \
+            'Function ' --emph "${FUNCNAME}" \
+            ' called with invalid third argument ' --emph "$3" ' (not a version number).'
+    fi
+    # Here we know the version regex is fulfilled, split them on dots using word splitting
+    local -r v1=(${1//./ }) v2=(${3//./ })
+    local index smaller_version='' longest_length=${#v1[@]}
+    if [[ ${#v1[@]} -lt ${#v2[@]} ]]; then
+        longest_length=${#v2[@]}
+    fi
+    for ((index = 0; index < longest_length; index++)); do
+        # NOTE: We take advantage of the arithmetic context to deal with leading
+        #       zeros, see https://stackoverflow.com/a/53075130. However, then we
+        #       need to expand variables with explicit parameter expansion and we
+        #       explicitly want to use zero ${var-0} for unset entries of v1 or v2.
+        if ((10#${v1[index]-0} == 10#${v2[index]-0})); then
+            continue
+        elif ((10#${v1[index]-0} > 10#${v2[index]-0})); then
+            smaller_version=$3
+            break
+        else
+            smaller_version=$1
+            break
+        fi
+    done
+    # If smaller_version remained unset the two versions are equal!
+    case "$2" in
+        == | = | '>=' | '<=' | -eq | -ge | -le)
+            if [[ "${smaller_version}" == '' ]]; then
+                return 0
+            fi
+            ;;& # Note that we continue testing the following cases here!
+        != | -ne)
+            [[ "${smaller_version}" != '' ]]
+            ;;
+        '>' | '>=' | -gt | -ge)
+            [[ "${smaller_version}" == "$3" ]]
+            ;;
+        '<' | '<=' | -lt | -le)
+            [[ "${smaller_version}" == "$1" ]]
+            ;;
+        *)
+            Print_Internal_And_Exit \
+                'Unreachable code reached in function ' --emph "${FUNCNAME}" \
+                ' called with: ' --emph "$1 $2 $3"
+            ;;
+    esac
 }
 
 : << 'DOCSTRING'

--- a/bash/utility_functions.bash
+++ b/bash/utility_functions.bash
@@ -148,8 +148,8 @@ function Is_Version()
             ;;
         *)
             Print_Internal_And_Exit \
-                'Unreachable code reached in function ' --emph "${FUNCNAME}" \
-                ' called with: ' --emph "$1 $2 $3"
+                'Unreachable code (by design) executed in function ' \
+                --emph "${FUNCNAME}" ', called with: ' --emph "$1 $2 $3"
             ;;
     esac
 }

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -14,7 +14,7 @@ It will speed up the code review and avoid comments about codebase notation.
     Sounds like magic?
     No, it simply means that there are tests for basically every functionality. :innocent:
     You are requested to stick to this existing aspect and, possibly, device and why not write tests for your new code before implementing the code itself.
-    A sufficiently handy testing framework has been developed tailored on this project and you find the needed information about it in a dedicated page [:material-arrow-right-box: testing framework](testing_framework.md).
+    A sufficiently handy testing framework has been developed tailored to this project and you find the needed information about it in a dedicated page [:material-arrow-right-box: testing framework](testing_framework.md).
     **The basic idea is that adding new tests is as simple as adding a new function.**
 
 !!! warning "It's a Bash project!"

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -60,7 +60,7 @@ Assumptions that are crucial to know before even getting to the code have a dedi
     ---
 
     Tests are the key to be confident that the code works as expected.
-    A testing framework has been developed tailored on the project.
+    A testing framework has been developed tailored to the project.
     Adding new tests is as simple as writing a new function!
 
     [:material-arrow-right-box:&nbsp; Check it out!](testing_framework.md)

--- a/docs/developer/utility_functions.md
+++ b/docs/developer/utility_functions.md
@@ -2,10 +2,10 @@
 
 :simple-gnubash: Bash world is often the realm of the **do it yourself**. :innocent:
 This is belonging to the nature of the language as it is very unusual to have libraries with functionality to be reused.
-However, it is very simple to provide the codebase with some utility function tailored on the needs of the project.
+However, it is very simple to provide the codebase with some utility function tailored to the needs of the project.
 In the following you will find an overview of what is available in the codebase.
 
-!!! warning "These functions are tailored on the project"
+!!! warning "These functions are tailored to the project"
     The following functions should not be considered as a library.
     Actually most of them would not work if copied and pasted in another project.
     Be aware that some of them depend on project-specific aspects (e.g. they use the logger or they assume that the shell used options are on) and, sometimes, make use of other utility functions.

--- a/docs/developer/utility_functions.md
+++ b/docs/developer/utility_functions.md
@@ -32,6 +32,16 @@ In the following you will find an overview of what is available in the codebase.
         --8<-- "bash/utility_functions.bash:Element_In_Array_Matches-ex"
         ```
 
+## Version comparison utilities
+
+??? utility-func "`Is_Version`"
+    === "Description"
+        --8<-- "bash/utility_functions.bash:Is_Version-desc"
+    === "Call example"
+        ```bash
+        --8<-- "bash/utility_functions.bash:Is_Version-ex"
+        ```
+
 ## Variables- and functions-related utilities
 
 ??? utility-func "`Call_Function_If_Existing_Or_Exit`"

--- a/tests/command_line_parser_for_tests.bash
+++ b/tests/command_line_parser_for_tests.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -40,7 +40,7 @@ function Parse_Tests_Command_Line_Options()
         case $1 in
             -h | --help)
                 __static__Print_Helper
-                exit ${HYBRID_success_exit_code}
+                exit 0
                 shift
                 ;;
             -r | --report-level)
@@ -62,7 +62,7 @@ function Parse_Tests_Command_Line_Options()
                     fi
                 else
                     __static__Print_List_Of_Tests
-                    exit ${HYBRID_success_exit_code}
+                    exit 0
                 fi
                 shift 2
                 ;;

--- a/tests/functional_tests_Afterburner_only.bash
+++ b/tests/functional_tests_Afterburner_only.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -10,8 +10,7 @@
 function __static__Check_Successful_Handler_Run()
 {
     if [[ $1 -ne 0 ]]; then
-        exit_code=${HYBRID_failure_exit_code} Print_Fatal_And_Exit \
-            'Hybrid-handler unexpectedly failed.'
+        exit_code=1 Print_Fatal_And_Exit 'Hybrid-handler unexpectedly failed.'
         return 1
     fi
     Check_If_Software_Produced_Expected_Output 'Afterburner' "$(pwd)/Afterburner"

--- a/tests/unit_tests_utility_functions.bash
+++ b/tests/unit_tests_utility_functions.bash
@@ -370,7 +370,7 @@ function Unit_Test__utility-compare-versions()
     )
     for args in "${test_cases[@]}"; do
         Call_Codebase_Function_In_Subshell Is_Version ${args} # Split args using word splitting!
-        if [[ $? -ne ${HYBRID_success_exit_code} ]]; then
+        if [[ $? -ne 0 ]]; then
             Print_Error 'Versions test ' --emph "${args}" ' unexpectedly failed.'
             ((counter++))
         fi

--- a/tests/unit_tests_utility_functions.bash
+++ b/tests/unit_tests_utility_functions.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -338,4 +338,42 @@ function Unit_Test__utility-files-existence()
         return 1
     fi
     rm 'link_test'
+}
+
+function Unit_Test__utility-compare-versions()
+{
+    local counter=0 args
+    local -r test_cases=(
+        '1 = 1'
+        '1 -eq 1'
+        '2.1 < 2.2.0'
+        '2.1 -lt 2.2.0'
+        '3.0.4.10 > 3.0.4.2'
+        '3.0.4.10 -gt 3.0.4.2'
+        '4.08 < 4.08.01'
+        '4.08 -lt 4.08.01'
+        '42.1.999 < 42.2'
+        '3.2 < 3.2.0.0.0.1'
+        '1.2 < 2.1'
+        '2.1 > 1.2'
+        '5.6.7 = 5.6.7'
+        '1.01.1 == 1.1.1'
+        '1.1.1 = 1.01.1'
+        '1 = 1.0'
+        '1.0.0 = 001'
+        '1.0.2.0 != 1.0.2.01'
+        '1.0.2.0 -ne 1.0.2.01'
+        '1 >= 1.0'
+        '1 -ge 1.0'
+        '1 <= 1.0'
+        '1 -le 1.0'
+    )
+    for args in "${test_cases[@]}"; do
+        Call_Codebase_Function_In_Subshell Is_Version ${args} # Split args using word splitting!
+        if [[ $? -ne ${HYBRID_success_exit_code} ]]; then
+            Print_Error 'Versions test ' --emph "${args}" ' unexpectedly failed.'
+            ((counter++))
+        fi
+    done
+    return ${counter} # Fine as long as we have less than 256 test clauses! ;)
 }

--- a/tests/utility_functions_functional.bash
+++ b/tests/utility_functions_functional.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -30,18 +30,18 @@ function Check_If_Software_Produced_Expected_Output()
     esac
     local -r folder_content=("${folder}"/*)
     if [[ ${#folder_content[@]} -ne 1 || ! -d ${folder_content[0]} ]]; then
-        exit_code=${HYBRID_failure_exit_code} Print_Fatal_And_Exit \
+        exit_code=${HYBRID_fatal_logic_error} Print_Fatal_And_Exit \
             'Not exactly one ID folder found in ' --emph "${folder}" '.'
     fi
     unfinished_files=("${folder}"/*/*.{unfinished,lock})
     output_files=("${folder}"/*/*)
     if [[ ${#unfinished_files[@]} -gt 0 ]]; then
-        exit_code=${HYBRID_failure_exit_code} Print_Fatal_And_Exit \
+        exit_code=${HYBRID_fatal_logic_error} Print_Fatal_And_Exit \
             'Some unexpected ' --emph '.{unfinished,lock}' ' output file remained' \
-            'in ' --emph "${folder}"
+            'in ' --emph "${folder}" '.'
         return 1
     elif [[ ${#output_files[@]} -ne ${expected_output_files} ]]; then
-        exit_code=${HYBRID_failure_exit_code} Print_Fatal_And_Exit \
+        exit_code=${HYBRID_fatal_logic_error} Print_Fatal_And_Exit \
             'Expected ' --emph "${expected_output_files}" ' output files in ' \
             --emph "${folder}" " folder, but ${#output_files[@]} found."
         return 1


### PR DESCRIPTION
This refactoring extracted (and improved) a `__static__` function about OS requirements moving it into the utility functions pool.

> [!WARNING]
> As I remarked in a comment, this new function must use Bash only, as we want to use it when checking OS requirements. This makes the implementation slightly more technical, but the amplification comments should help following it.

@RobinSattler Feel free to play with the unit test editing the test cases there. Maybe you can catch something I missed. 😉 In any case, I suggest you to review and ideally merge this PR before starting working on #52. 