### PR TITLE
Improve user guide and mention Docker image in it

### DIFF
--- a/configs/smash_initial_conditions.yaml
+++ b/configs/smash_initial_conditions.yaml
@@ -26,6 +26,6 @@ Modi:
         Fermi_Motion: frozen
         Impact:
             Max: 2.3
-        
+
         Initial_Conditions:
             Type: "Constant_Tau"

--- a/docs/user/FAQ/index.md
+++ b/docs/user/FAQ/index.md
@@ -1,5 +1,124 @@
 # Frequently asked questions
 
+### How can I add a software key to a configuration file?
+
+Using the hybrid handler, many different programs are run and each of them needs a configuration file.
+The hybrid handler also needs a configuration file and having many of these might lead to some confusion.
+
+All the configuration files of the separate software for each state _can_ be specified by the user, but *do not have to*.
+The hybrid handler is using default ones, which are shipped in the :file_folder: **configs** folder.
+You can have a look to these files to see which keys are used there.
+
+Since using the `Software_keys` key in the hybrid handler configuration file it is only possible to **change** the value of an existing input key in the software configuration file, it would result in an error to attempt to add a missing one.
+Analogously, there is no mechanism to remove keys from the default base software configuration file used by the handler.
+
+Let's see in a concrete example how to proceed if different keys are needed.
+Assume we want to run the :fire: afterburner stage asking SMASH not to use the grid for interaction lookup (this might be of course any other key).
+The following setup would not work, as the `Use_Grid` key in the `General` section is not provided in the default base configuration file for the afterburner.
+
+=== "Hybrid-handler configuration file"
+    ``` {.yaml .annotate}
+    Afterburner:
+        Executable: "/path/to/smash"
+        Software_keys:
+            General:
+                End_Time: 500
+                Nevents: 200
+                Use_Grid: False # (1)!
+    ```
+
+    1. :warning: This triggers an error as it is missing in the afterburner base configuration file!
+
+=== ":fire: SMASH Afterburner base configuration file"
+    ```yaml
+    Logging:
+        default: INFO
+
+    General:
+        Modus:         List
+        Time_Step_Mode: None
+        Delta_Time:    0.1
+        End_Time:      10000.0
+        Randomseed:    -1
+        Nevents:       1000
+
+    Collision_Term:
+        Strings: True
+        String_Parameters:
+            Use_Monash_Tune: False
+
+    Output:
+        Particles:
+            Format:          ["Oscar2013"]
+
+    Modi:
+        List:
+            File_Directory: "."
+            Filename: "sampled_particles_list.oscar"
+    ```
+
+The correct way to fix the problem is to create a new SMASH afterburner configuration file, having all the keys that need to be modified and then modify them from the hybrid handler configuration file **after having specified that a custom configuration file should be used for the afterburner stage**.
+
+=== "Hybrid-handler configuration file"
+    ``` {.yaml .annotate}
+    Afterburner:
+        Executable: "/path/to/smash"
+        Config_file: "/path/to/my/base-config.yaml"
+        Software_keys:
+            General:
+                End_Time: 500
+                Nevents: 200
+                Use_Grid: False # (1)!
+    ```
+
+    1. :white_check_mark: Now this is working, as the key exists in the base configuration file.
+
+=== ":fire: My own SMASH Afterburner base configuration file"
+    ```yaml
+    Logging:
+        default: INFO
+
+    General:
+        Modus:         List
+        Time_Step_Mode: None
+        Delta_Time:    0.1
+        End_Time:      10000.0
+        Randomseed:    -1
+        Nevents:       1000
+        Use_Grid:      True
+
+    # [...] <- SAME AS BEFORE!
+    ```
+
+
+!!! tip "A possible way to go in real life"
+    <div class="grid" markdown>
+
+    In complex projects it might be handy to prepare base configuration files for the needed stages in the beginning.
+    A good idea might be to keep them close to the data in a known, dedicated folder.
+    This ensures reproducibility at any point during the project and can be seen as a good data management practice.
+    Of course, you will need to point to your custom base configuration files from within the hybrid handler configuration file in the different stages blocks.
+
+    ``` { .bash .no-copy }
+    📂 Project-directory
+    │
+    ├─ 📂 Custom_base_configuration_files
+    │   ├─── 🗒️ smash_IC.yaml
+    │   ├─── 🗒️ vhlle.txt
+    │   └─── ...
+    ├─ 📂 IC
+    │   └─── ...
+    ├─ 📂 Hydro
+    │   └─── ...
+    └─── ...
+    ```
+
+    </div>
+
+!!! danger "Do not edit the shipped base configuration file!"
+    Although this might be a quick way to try out something, you should never prefer to change the base configuration files in the hybrid handler repository.
+    Your changes might get in conflict with future releases of the software or simply be undone by accident using Git inside the repository.
+
 ### How can I repeat the same run in parallel to increase statistics?
 
 The output folder in `do` mode is built by the hybrid handler in a way such that runs with different IDs do not interfere.
@@ -18,7 +137,6 @@ This can be exploited to easily start the same run several times with different 
     done
     wait
     ```
-    {.annotate}
 
     1.  The `SLURM_CPUS_ON_NODE` variable is peculiar to [slurm scheduler](https://slurm.schedmd.com/sbatch.html).
         This `for` loop should submit as many runs as the number of CPUs requested by the job.

--- a/docs/user/configuration_file.md
+++ b/docs/user/configuration_file.md
@@ -53,6 +53,12 @@ These are (with the corresponding software to be used):
 As a general comment, whenever a path has to be specified, both an absolute and a relative one are accepted.
 However, **it is strongly encouraged to exclusively use absolute paths** as relative ones should be specified w.r.t. different folders (most of the times relatively to the stage output directory).
 
+!!! tip "You only need the handler configuration file!"
+    Although each software needs a configuration file to be run, you generally do not need to create any.
+    The handler uses a default one if none is explicitly provided.
+    Keys in each software configuration files can be changed from the handler configuration file, without having to create specific configuration files for each software.
+    Refer to the [:material-arrow-right-box: `Software_keys`](configuration_file.md#Software-keys) description for further information.
+
 !!! info "Enforced sanity rules"
     Since the hybrid handler understands which software should be run from the presence of the corresponding section, there are a couple of totally natural rules that are enforced and will make the handler fail if violated.
 
@@ -73,12 +79,14 @@ However, **it is strongly encouraged to exclusively use absolute paths** as rela
     Path to the software specific configuration file.
     If not specified, the file shipped in the ***configs*** folder is used.
 
+<i id="Software-keys"></i>
 ???+ config-key "`Software_keys`"
 
     The value of this key is a YAML map and should be used to change values of the software configuration file.
     It is not possible to add or remove keys, but only change already existing ones.
     If you need to add a key to the software default configuration file, you should create a custom one and specify it via the `Config_file` key.
     Depending on your needs, you could also create a more complete configuration file and change the values of some keys in your run(s) via this key.
+    [:material-arrow-right-box: How is this achieved in practice?](FAQ/index.md#how-can-i-add-a-software-key-to-a-configuration-file)
 
 <i id="scan-parameters"></i>
 ???+ config-key "`Scan_parameters`"
@@ -163,9 +171,9 @@ Sampler:
         surface: /path/to/custom/freezeout.dat
 ```
 
-For the hadron sampler section, there is the additional option to use an alternative sampling software, the FIST sampler. By default, the SMASH-hadron-sampler is used. 
-For using the FIST sampler, the additional input key `Module` has to be set to `FIST`. 
-This allows also two separate keys `Particle_file` and `Decay_file` to be set, which are the paths to the particle and decay list files respectively, which are shipped with Thermal-FIST. 
+For the hadron sampler section, there is the additional option to use an alternative sampling software, the FIST sampler. By default, the SMASH-hadron-sampler is used.
+For using the FIST sampler, the additional input key `Module` has to be set to `FIST`.
+This allows also two separate keys `Particle_file` and `Decay_file` to be set, which are the paths to the particle and decay list files respectively, which are shipped with Thermal-FIST.
 Setting these keys is compulsory. Additionally, using the FIST sampler changes the names of several of the `Software_keys`. Please refer to the default config for the FIST sampler in :file_folder: ***configs***.
 
 ???+ config-key "`Module`"

--- a/docs/user/docker_image.md
+++ b/docs/user/docker_image.md
@@ -1,0 +1,26 @@
+# An Ubuntu-based framework
+
+Next to the hybrid handler repository, a Docker image based on Ubuntu to compile all SMASH-vHLLE-hybrid software and use the hybrid handler [is available](https://github.com/smash-transport/smash-vhlle-hybrid/pkgs/container/smash-vhlle-hybrid).
+Feel free to download it and use it.
+In the container all prerequisites of the hybrid handler are satisfied and the user can easily use it.
+The image does not contain the supported software and its installation is left to the user.
+However, most libraries are available in the image an a list of them can be obtained inspecting the container.
+```console title="A possible output of docker inspect"
+$ docker inspect \
+> -f '{{index .Config.Labels "installed.software.versions" }}' \
+> smash-vhlle-hybrid-framework:latest | sed 's/ | /\n/g'
+Doxygen 1.9.1
+ROOT 6.26.10
+HepMC 3.2.5
+Rivet 3.1.7
+Yoda 1.9.7
+Fastjet 3.4.0
+Fjcontrib 1.049
+Cppcheck 2.8
+Cpplint 1.6.0
+yq 4.44.3
+```
+
+!!! info "The container working directory"
+    Running the Docker image, the container will get you in a :file_folder: **/Software** directory that is containing the installed software which is needed to e.g. compile SMASH.
+    Please, note that Pythia is missing and it is up to the user to install the needed version of it.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -62,4 +62,12 @@ Once cloned the repository, you can simply run the `Hybrid-handler` script[^1].
 
     [:material-arrow-right-box:&nbsp; Frequently asked questions](FAQ/index.md)
 
+-   :whale:{ .lg .middle } &nbsp; __Run it in a Docker container__
+
+    ---
+
+    Check out our Ubuntu-based Docker image to install software and use the handler.
+
+    [:material-arrow-right-box:&nbsp; Shipped Docker image](docker_image.md)
+
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - user/index.md
     - Getting started:
        - Prerequisites: user/prerequisites.md
+       - A Docker image: user/docker_image.md
        - Execution modes: user/execution_modes.md
        - Handler configuration file: user/configuration_file.md
        - Predefined configuration files: user/predefined_configs.md


### PR DESCRIPTION
This closes #55 and closes #56.

I have extended the documentation a bit. In particular:
* I added a FAQ trying to explain pedantically how the base config files work;
* I mentioned the Docker image in the user guide.

@NGoetz I assigned you as you were assigned to the issues. Maybe somebody else can help here? @Carl-Rosenkvist @RenHirayama It should not take more than 15 minutes.

I suggest you to pull this branch and run `mkdocs serve` from it and then open http://127.0.0.1:8000/smash-vhlle-hybrid/ in your browser. Then read there the rendered changed parts.