### PR TITLE
Implement procedure to print faulty keys in YAML replacement

### DIFF
--- a/.github/workflows/github-actions-on-github-servers.yml
+++ b/.github/workflows/github-actions-on-github-servers.yml
@@ -89,6 +89,8 @@ jobs:
         else
             BASH_EXE=$(which bash)
         fi
+        # we print the yq version for information
+        printf "\n$(yq --version)\n"
         # we print the bash version to check that we used the desired one
         printf "\n$(${BASH_EXE} --version)\n"
         # we set the TERM environment variable (used by utilities exploited in the tests)

--- a/bash/software_input_functionality.bash
+++ b/bash/software_input_functionality.bash
@@ -99,7 +99,7 @@ function __static__Abort_With_Descriptive_Report_If_YAML_Replacement_Is_Not_Poss
     # Here the basic idea is to go through the YAML tree and create complete
     # paths to the values concatenating all keys with a period. Array indices
     # are replaced by "[]" as we are not interested at tracking them (a key
-    # having an array value can be substituted by another array).
+    # having an array value can be substituted by one with another array value).
     #
     # NOTE: One might think that working with "properties"
     #         -> https://mikefarah.gitbook.io/yq/usage/properties
@@ -165,7 +165,7 @@ function __static__Abort_With_Descriptive_Report_If_YAML_Replacement_Is_Not_Poss
     done
     if [[ ${#list_of_faulty_keys[@]} -ne 0 ]]; then
         # If this function was called from a TXT replacement, drop YAML hint for user
-        local yaml_description=' (YAML map keys concatenated by "." and arrays denoted by "[]")'
+        local yaml_description=' (YAML map keys concatenated by ".")'
         if [[ ${FUNCNAME[2]-} = *Txt* ]]; then
             yaml_description=''
         fi

--- a/docs/user/FAQ/index.md
+++ b/docs/user/FAQ/index.md
@@ -119,6 +119,30 @@ The correct way to fix the problem is to create a new SMASH afterburner configur
     Although this might be a quick way to try out something, you should never prefer to change the base configuration files in the hybrid handler repository.
     Your changes might get in conflict with future releases of the software or simply be undone by accident using Git inside the repository.
 
+### Can I collide particles other than nuclei in the IC stage?
+
+You might have tried to use SMASH as initial-conditions software specifying a pion as the projectile via the following configuration file, but this was not accepted by the hybrid handler.
+
+``` {.yaml .annotate title="Hybrid-handler configuration file"}
+IC:
+    Executable: "/path/to/smash"
+    Software_keys:
+        Modi:
+            Collider:
+                Projectile:
+                    Particles: {211: 1} # (1)!
+```
+
+ 1. :warning: This triggers an error as `Particles` is a YAML map and it contains a sub-map.
+    Since `211` is a map key, which is not present in the base configuration file, this line triggers an error.
+
+The SMASH :cloud_tornado: `IC` base configuration file is set up to collide nuclei and, therefore, both the projectile and the target are made of protons and neutrons.
+These are specified **using PDG codes as YAML map keys** in the configuration file.
+Any attempt to use different particles is a try to use a new key in the configuration file, namely one not present in the base configuration file!
+If you need to collide particles other than protons and nucleons, you need your own base configuration file.
+Check out [this other question](#how-can-i-add-a-software-key-to-a-configuration-file) for detailed instructions.
+
+
 ### How can I repeat the same run in parallel to increase statistics?
 
 The output folder in `do` mode is built by the hybrid handler in a way such that runs with different IDs do not interfere.

--- a/tests/unit_tests_software_input_functionality.bash
+++ b/tests/unit_tests_software_input_functionality.bash
@@ -47,7 +47,7 @@ function Unit_Test__replace-in-software-input-YAML()
     keys_to_be_replaced=$'New_key: value\nFoo:\n  Bar: [42, {Map: New}]\n  bar: True\n'
     Call_Codebase_Function_In_Subshell __static__Replace_Keys_Into_YAML_File &> /dev/null
     if [[ $? -eq 0 ]]; then
-        Print_Error 'Valid YAML replacement but with non existent keys in valid file succeeded.'
+        Print_Error 'Valid YAML replacement but with non-existent keys in valid file succeeded.'
         return 1
     fi
     #---------------------------------------------------------------------------

--- a/tests/unit_tests_software_input_functionality.bash
+++ b/tests/unit_tests_software_input_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -40,6 +40,30 @@ function Unit_Test__replace-in-software-input-YAML()
     Call_Codebase_Function_In_Subshell __static__Replace_Keys_Into_YAML_File &> /dev/null
     if [[ $? -eq 0 ]]; then
         Print_Error 'Valid YAML replacement but with non existent key in valid file succeeded.'
+        return 1
+    fi
+    #---------------------------------------------------------------------------
+    printf 'Key: Value\nFoo:\n  Bar: [0,1,2]\n' > "${base_input_file}"
+    keys_to_be_replaced=$'New_key: value\nFoo:\n  Bar: [42, {Map: New}]\n  bar: True\n'
+    Call_Codebase_Function_In_Subshell __static__Replace_Keys_Into_YAML_File &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        Print_Error 'Valid YAML replacement but with non existent keys in valid file succeeded.'
+        return 1
+    fi
+    #---------------------------------------------------------------------------
+    printf 'Key: Value\nFoo:\n  Bar: [0,1,2]\n' > "${base_input_file}"
+    keys_to_be_replaced=$'Key: new_value\nFoo:\n  Bar: 42\n'
+    Call_Codebase_Function_In_Subshell __static__Replace_Keys_Into_YAML_File &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        Print_Error 'Valid YAML replacement but changing array value to scalar in valid file succeeded.'
+        return 1
+    fi
+    #---------------------------------------------------------------------------
+    printf '0: Zero\nRoman:\n  1: I\n' > "${base_input_file}"
+    keys_to_be_replaced=$'0: NULL\nRoman:\n  2: II\n'
+    Call_Codebase_Function_In_Subshell __static__Replace_Keys_Into_YAML_File &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        Print_Error 'Valid YAML replacement but changing numeric map key in valid file succeeded.'
         return 1
     fi
     #---------------------------------------------------------------------------


### PR DESCRIPTION
This closes #62.

This change was not trivial, but made me notice that actually the previous approach was not sound (see commit message for further information).

Running the example reported by @RobinSattler in #62 the user now gets

<img width="799" alt="image" src="https://github.com/user-attachments/assets/54dbabfe-cdd5-413b-bdd6-50bd99a6b111" />

which is more descriptive. For YAML files one gets e.g.

<img width="799" alt="image" src="https://github.com/user-attachments/assets/d27dc1d0-5ab5-42e0-86f9-938ee4203d58" />

where the `particles` without capital `P` makes the handler fail.

However, the implemented code so far would not allow to change `Particles` in SMASH from protons and neutrons to something totally different. Trying e.g. to shoot 4 pions in the IC stage does not work.

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/c27cbb01-cec9-4183-a070-785aa08f3708" />

I did not think so much about this, but I am afraid that there is not really a general way to cope with this. So the question is: How much is being able to cope with this case needed? 🤔 @NGoetz @RenHirayama @RobinSattler What's your take on this? I see here two alternatives:

1. We leave the code so and discuss this corner case in the documentation.
2. We implement in some way an exception for `{Modi: {Collider: {Projectile: {Particles: ...}}}}` and `{Modi: {Collider: {Target: {Particles: ...}}}}`.

Option 2 does not sound so trivial and, therefore, I would like to brainstorm together before investing more effort on this.

