### PR TITLE
Fix bugs in `add_spectators.py` script and restrict possibility of adding spectators to only one IC event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-# Changelog
+# CHANGELOG
 
-The changelog can be found in the documentation of the project.
-Just click [here](https://smash-transport.github.io/smash-vhlle-hybrid/latest/user/changelog).
+The CHANGELOG can be found [here](https://smash-transport.github.io/smash-vhlle-hybrid/latest/user/CHANGELOG/) in the documentation of the project.

--- a/bash/Afterburner_functionality.bash
+++ b/bash/Afterburner_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -77,6 +77,19 @@ function __static__Ensure_Consistency_Of_Afterburner_Input()
     fi
 }
 
+function __static__Run_Add_Spectators_Python_Script()
+{
+    local python_fatal_value_error
+    # NOTE: To extract the right error code in the python script, it has to be handed to it right
+    #       before calling the script since the error codes are not exported by default.
+    python_fatal_value_error=${HYBRID_fatal_value_error} \
+        "${HYBRID_external_python_scripts[Add_spectators_from_IC]}" \
+        '--sampled_particle_list' "${HYBRID_software_input_file[Afterburner]}" \
+        '--initial_particle_list' "${HYBRID_software_input_file[Spectators]}" \
+        '--output_file' "${target_link_name}" \
+        '--smash_config' "${HYBRID_software_output_directory[IC]}/config.yaml" 2> /dev/null
+}
+
 function __static__Create_Sampled_Particles_File_Or_Symbolic_Link_With_Or_Without_Spectators()
 {
     local -r target_link_name="${HYBRID_software_output_directory[Afterburner]}/${HYBRID_afterburner_list_filename}"
@@ -92,11 +105,29 @@ function __static__Create_Sampled_Particles_File_Or_Symbolic_Link_With_Or_Withou
             "${HYBRID_software_input_file[Afterburner]}" \
             "${HYBRID_software_input_file[Spectators]}"
         # Run Python script to add spectators
-        "${HYBRID_external_python_scripts[Add_spectators_from_IC]}" \
-            '--sampled_particle_list' "${HYBRID_software_input_file[Afterburner]}" \
-            '--initial_particle_list' "${HYBRID_software_input_file[Spectators]}" \
-            '--output_file' "${target_link_name}" \
-            '--smash_config' "${HYBRID_software_output_directory[IC]}/config.yaml"
+        # NOTE: Since the errexit option enabled, the python script to add the spectators is run in the if-statement
+        #       and the possible exit code is accessed at the very beginning of the else-clause.
+        local python_exit_code
+        if __static__Run_Add_Spectators_Python_Script; then
+            # BE AWARE: The negation of the if-clause does not work because then the exit code cannot
+            #           be extracted properly (it will always be 0 because of the true if-statement).
+            :
+        else
+            python_exit_code=$?
+            if [[ ${python_exit_code} -eq ${HYBRID_fatal_value_error} ]]; then
+                exit_code=${HYBRID_fatal_value_error} Print_Fatal_And_Exit \
+                    'It was attempted to add spectators from multiple IC events to the sampled particles file. Only' \
+                    'running one IC event is supported when using the Afterburner config key ' \
+                    --emph "Add_spectators_from_IC: true" '.'
+            elif [[ ${python_exit_code} -eq 2 ]]; then
+                Print_Internal_And_Exit \
+                    'The handing over of the ' --emph "python_fatal_value_error" \
+                    ' to the Python script that adds spectators from the IC did not work.'
+            else
+                Print_Fatal_And_Exit \
+                    'Adding spectators from the IC particles to the sampled particles file failed.'
+            fi
+        fi
     else
         if [[ ! -f "${target_link_name}" || -L "${target_link_name}" ]]; then
             ln -s -f "${HYBRID_software_input_file[Afterburner]}" "${target_link_name}"

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -48,6 +48,8 @@ Given a version number `X.Y.Z`,
 
     **Changes:**
 
+    :sos: &nbsp; Fix how spectators are added from the `IC` output into the `Afterburner` input file. This now works for all SMASH versions. The spectators from the target were not properly considered beforehand. Additionally, the adding of spectators is currently only allowed if only one `IC` event was run.
+
     :recycle: &nbsp; Renamed the copied/linked afterburner inputfile containing the sampled particles (and possibly spectators) from :material-file: _sampled_particles_list.oscar_ to :material_file: _sampled_particles.oscar_. Note that this is not a breaking change because this file is created into the :file_folder: **Afterburner** folder at the beginning of such a stage.
 
 

--- a/python/add_spectators.py
+++ b/python/add_spectators.py
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -29,12 +29,12 @@ def get_initial_nucleons_from_config():
         nuclei and read off the number of constituents.
     '''
     N_initial_nucleons = 0
-    with open(args.smash_config, 'r') as file:
-        data_config = yaml.safe_load(file)
+    with open(args.smash_config, 'r') as config_file:
+        data_config = yaml.safe_load(config_file)
 
     try:
         projectile_particles = data_config['Modi']['Collider']['Projectile']['Particles']
-        target_particles = data_config['Modi']['Collider']['Projectile']['Particles']
+        target_particles = data_config['Modi']['Collider']['Target']['Particles']
 
         for particle in projectile_particles.keys():
             N_initial_nucleons += projectile_particles[particle]
@@ -42,8 +42,9 @@ def get_initial_nucleons_from_config():
         for particle in target_particles.keys():
             N_initial_nucleons += target_particles[particle]
     except:
-        print("The config file does not contain the necessary information about the projectile and target nuclei.")
-        sys.exit()
+        print("The config file does not contain the necessary information "
+              "about the projectile and/or target nuclei.")
+        sys.exit(1)
 
     return N_initial_nucleons
 
@@ -63,7 +64,9 @@ def extract_spectators():
         for line in f:
             if line[0] == "#": continue  # Comment line
             # Is initial nucleon and has not interacted
-            if ((int(line.split()[10]) <= N_nucleons) and (int(line.split()[12]) == 0) ):
+            particle_id = int(line.split()[10])
+            N_collisions = int(line.split()[12])
+            if ((particle_id <= N_nucleons) and (N_collisions == 0)):
                 # To properly determine the spectators, we need the extended output.
                 # For the final particle list that is used to run the afterburner
                 # we do however only need it in the non-extended version. So we
@@ -89,15 +92,21 @@ def write_full_particle_list(spectator_list):
     N_spectators = len(spectator_list)
     updated_particle_list = open(args.output_file, 'w')
 
-    with open(args.sampled_particle_list, 'r') as f:
-        for line in f:
+    with open(args.sampled_particle_list, 'r') as sampler_output_file:
+        for line in sampler_output_file:
             # Find header of each new event
-            if (line.startswith('# event') and len(line.split()) == 5 ):
-                # 5th column contains the number of sampled particles for each
-                # event. To this value the number of spectators needs to be added
-                particles_in_event = int(line.split()[4]) + N_spectators
-                # Update last entry in list (number of particles)
-                newline = ' '.join(line.split()[:-1]) + str(particles_in_event) + '\n'
+            if (line.startswith('# event') and ("out" in line) and (not "end" in line)):
+                # The string after 'out' contains the number of sampled particles for
+                # each event. The number of spectators needs to be added to this value.
+                partitioned_line = line.partition('out ')
+                N_sampled_particles = int(partitioned_line[-1].split()[0])
+                rest_of_line = partitioned_line[-1].split()[1:]
+                particles_in_event = N_sampled_particles + N_spectators
+                # Update number of particles in event header
+                newline = ''.join(partitioned_line[:-1]) + str(particles_in_event)
+                if rest_of_line:
+                    newline += ' ' + ' '.join(rest_of_line)
+                newline += '\n'
 
                 # (I) write header for new event
                 updated_particle_list.write(newline)
@@ -128,6 +137,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
 
-    get_initial_nucleons_from_config()
     spectators = extract_spectators()
     write_full_particle_list(spectators)

--- a/python/add_spectators.py
+++ b/python/add_spectators.py
@@ -12,6 +12,7 @@
 import argparse
 import yaml
 import sys
+import os
 
 '''
     This script adds the spectators of the collision, that were not included in
@@ -31,6 +32,16 @@ def get_initial_nucleons_from_config():
     N_initial_nucleons = 0
     with open(args.smash_config, 'r') as config_file:
         data_config = yaml.safe_load(config_file)
+
+        python_exit_code_string = os.environ.get("python_fatal_value_error")
+        if python_exit_code_string is None:
+            sys.exit(2)
+        python_exit_code = int(python_exit_code_string)
+        nevents_IC = data_config['General']['Nevents']
+        # The add_spectators.py script only supports adding spectators
+        # if just one IC event is run:
+        if nevents_IC != 1:
+            sys.exit(python_exit_code)
 
     try:
         projectile_particles = data_config['Modi']['Collider']['Projectile']['Particles']
@@ -139,3 +150,4 @@ if __name__ == '__main__':
 
     spectators = extract_spectators()
     write_full_particle_list(spectators)
+    sys.exit(0)


### PR DESCRIPTION
This fixes #65.

- I fixed the `add_spectators.py` script and it should now work SMASH version independent.
- Additionally, the handler will now print an error and exit when `Nevents` in the IC is not one and `Add_spectators_from_IC: true` is given in the afterburner config. It's important to state that this error and exit is only done in the afterburner stage so far, as soon as the python script `add_spectators.py` is called. The change to "sanity" check before the handler runs if more than one IC event is run combined with `Add_spectators_from_IC: true` in the afterburner section will be left for issue #68.
- On top of our testing framework, I did test runs with SMASH-3.1 and SMASH-3.2 (and the corresponding SMASH-hadron-sampler versions) and everything went as expected. I tested also SMASH-3.1 with the old script and with the new implementation and with the same random seed there is (basically) no difference, which is what we would expect for a symmetric collision (same nuclei as target and projectile).

One point up for discussion:
- Since PR #70 renames `sampled_particles_list.oscar` to `sampled_particles.oscar`, should we rename the command line option of the python script as well (e.g., from `--sampled_particle_list` to `--sampled_particles_file`)?

@RenHirayama, since you said that adding spectators is relevant for your research, I assign you as well to review.