### PR TITLE
Fix FIST sampler event number comparison with afterburner bug

### DIFF
--- a/bash/Afterburner_functionality.bash
+++ b/bash/Afterburner_functionality.bash
@@ -144,8 +144,18 @@ function __static__Check_If_Afterburner_Configuration_Is_Consistent_With_Sampler
     local -r config_afterburner="${HYBRID_software_configuration_file[Afterburner]}"
     if Element_In_Array_Equals_To 'Sampler' "${HYBRID_given_software_sections[@]}"; then
         local -r config_sampler="${HYBRID_software_configuration_file[Sampler]}"
+        local number_of_events_config_key_sampler
+        if [[ "${HYBRID_module[Sampler]}" = 'SMASH' ]]; then
+            number_of_events_config_key_sampler='number_of_events'
+        elif [[ "${HYBRID_module[Sampler]}" = 'FIST' ]]; then
+            number_of_events_config_key_sampler='nevents'
+        else
+            Print_Internal_And_Exit 'The used sampler module ' --emph "${HYBRID_module[Sampler]}" \
+                ' is not recognized by the function\n' --emph "${FUNCNAME}" \
+                '. This should not have happened.'
+        fi
         while read key value; do
-            if [[ "${key}" = 'number_of_events' ]]; then
+            if [[ "${key}" = "${number_of_events_config_key_sampler}" ]]; then
                 local events_sampler
                 events_sampler="${value}"
             fi
@@ -153,7 +163,7 @@ function __static__Check_If_Afterburner_Configuration_Is_Consistent_With_Sampler
         local events_afterburner
         events_afterburner=$(Read_From_YAML_String_Given_Key "$(< "${config_afterburner}")" 'General.Nevents')
         if [[ "${events_afterburner}" -gt "${events_sampler}" ]]; then
-            PrintAttention 'The number of events set to run in the afterburner (' \
+            Print_Attention 'The number of events set to run in the afterburner (' \
                 --emph "${events_afterburner}" ')\nis greater than the number of events sampled (' \
                 --emph "${events_sampler}" ').\n' \
                 --emph 'Nevents' ' in the afterburner configuration file is reset to ' --emph "${events_sampler}" '!'
@@ -161,7 +171,7 @@ function __static__Check_If_Afterburner_Configuration_Is_Consistent_With_Sampler
                 'YAML' "${config_afterburner}" \
                 "$(printf "%s:\n  %s:  %s\n" 'General' 'Nevents' "${events_sampler}")"
         elif [[ "${events_afterburner}" -lt "${events_sampler}" ]]; then
-            PrintAttention 'The number of events set to run in the afterburner (' \
+            Print_Attention 'The number of events set to run in the afterburner (' \
                 --emph "${events_afterburner}" ')\nis smaller than the number of events sampled (' \
                 --emph "${events_sampler}" ').' \
                 'Excess sampled events remain unused.' \

--- a/bash/Sampler_functionality.bash
+++ b/bash/Sampler_functionality.bash
@@ -210,7 +210,7 @@ function __static__Check_If_Sampler_Configuration_Is_Consistent_With_Hydro()
 
 function __static__State_Inconsistency_Of_Sampler_With_Hydro()
 {
-    PrintAttention 'The sampler and hydrodynamics parameters' \
+    Print_Attention 'The sampler and hydrodynamics parameters' \
         'are inconsistent in values for ' --emph "$1" ' correction.' \
         'Viscous corrections are present in hydrodynamic stage,' \
         'but will not be applied in the Cooper-Frye sampling,' \

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -44,12 +44,11 @@ Given a version number `X.Y.Z`,
     This symbol indicates _changes that deserve particular attention by the user_.
 
 
-!!! work-in-progress "Unreleased"
+### SMASH-vHLLE-hybrid-2.1.3
 
-    **Changes:**
+???+ success "&nbsp; :date: &nbsp; Release date: 2025-06-05 &emsp; :left_right_arrow: &nbsp; [Compare changes to previous version](https://github.com/smash-transport/smash-vhlle-hybrid/compare/SMASH-vHLLE-hybrid-2.1.2...SMASH-vHLLE-hybrid-2.1.3)"
 
     :sos: &nbsp; Fix hybrid handler crash due to accessing an unbound variable when trying to run both the `Sampler` and the `Afterburner` stages using the FIST sampler.
-
 
 
 ### SMASH-vHLLE-hybrid-2.1.2

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -44,6 +44,14 @@ Given a version number `X.Y.Z`,
     This symbol indicates _changes that deserve particular attention by the user_.
 
 
+!!! work-in-progress "Unreleased"
+
+    **Changes:**
+
+    :sos: &nbsp; Fix hybrid handler crash due to accessing an unbound variable when trying to run both the `Sampler` and the `Afterburner` stages using the FIST sampler.
+
+
+
 ### SMASH-vHLLE-hybrid-2.1.2
 
 ???+ success "&nbsp; :date: &nbsp; Release date: 2025-05-16 &emsp; :left_right_arrow: &nbsp; [Compare changes to previous version](https://github.com/smash-transport/smash-vhlle-hybrid/compare/SMASH-vHLLE-hybrid-2.1.1...SMASH-vHLLE-hybrid-2.1.2)"

--- a/docs/user/configuration_file.md
+++ b/docs/user/configuration_file.md
@@ -199,7 +199,7 @@ Sampler:
     Particle_file: /path/to/list.dat
     Decays_file: /path/to/decays.dat
     Software_keys:
-        hypersurface: /path/to/custom/freezeout.dat
+        hypersurface_file: /path/to/custom/freezeout.dat
 ```
 
 ## :fire: &nbsp; The afterburner section

--- a/tests/unit_tests_Afterburner_functionality.bash
+++ b/tests/unit_tests_Afterburner_functionality.bash
@@ -186,23 +186,20 @@ function Clean_Tests_Environment_For_Following_Test__Afterburner-check-all-input
     rm -r "${HYBRID_output_directory}"
 }
 
-function Make_Test_Preliminary_Operations__Afterburner-config-consistent-with-sampler()
+function __static__Set_Events_Config_Key_For_Sampler_And_Run_Consistency_Check()
 {
-    Do_Preliminary_Afterburner_Setup_Operations
-    HYBRID_given_software_sections+=('Sampler')
-    HYBRID_software_executable[Sampler]=$(which echo) # Use command as fake executable
-    HYBRID_optional_feature[Add_spectators_from_IC]='FALSE'
-    Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
-}
-
-function Unit_Test__Afterburner-config-consistent-with-sampler()
-{
-    mkdir -p "${HYBRID_software_output_directory[Sampler]}"
-    # Sampler config file with default number_of_events
+    local number_of_events_config_key_sampler
     local -r events_sampler=1000
-    printf '%s   %s\n' "number_of_events" "${events_sampler}" > "${HYBRID_software_configuration_file[Sampler]}"
+    if [[ "${HYBRID_module[Sampler]}" = 'SMASH' ]]; then
+        number_of_events_config_key_sampler='number_of_events'
+    elif [[ "${HYBRID_module[Sampler]}" = 'FIST' ]]; then
+        number_of_events_config_key_sampler='nevents'
+    fi
+    mkdir -p "${HYBRID_software_output_directory[Sampler]}"
+    printf '%s   %s\n' "${number_of_events_config_key_sampler}" "${events_sampler}" > \
+        "${HYBRID_software_configuration_file[Sampler]}"
     mkdir -p "${HYBRID_software_output_directory[Afterburner]}"
-    # Afterburner config file with higher number_of_events
+    # Afterburner config file with higher number of events
     local -r events_entered=1500
     printf '%s:\n  %s:  %s\n' 'General' 'Nevents' "${events_entered}" > \
         "${HYBRID_software_configuration_file[Afterburner]}"
@@ -217,8 +214,46 @@ function Unit_Test__Afterburner-config-consistent-with-sampler()
     fi
 }
 
-function Clean_Tests_Environment_For_Following_Test__Afterburner-config-consistent-with-sampler()
+function Make_Test_Preliminary_Operations__Afterburner-config-consistent-with-sampler-SMASH()
 {
+    Do_Preliminary_Afterburner_Setup_Operations
+    HYBRID_module[Sampler]='SMASH'
+    HYBRID_given_software_sections+=('Sampler')
+    HYBRID_software_executable[Sampler]="${HYBRIDT_tests_folder}/mocks/echo.py"
+    HYBRID_optional_feature[Add_spectators_from_IC]='FALSE'
+    Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
+}
+
+function Unit_Test__Afterburner-config-consistent-with-sampler-SMASH()
+{
+    __static__Set_Events_Config_Key_For_Sampler_And_Run_Consistency_Check
+}
+
+function Clean_Tests_Environment_For_Following_Test__Afterburner-config-consistent-with-sampler-SMASH()
+{
+    rm -r "${HYBRID_output_directory}"
+}
+
+function Make_Test_Preliminary_Operations__Afterburner-config-consistent-with-sampler-FIST()
+{
+    Do_Preliminary_Afterburner_Setup_Operations
+    HYBRID_module[Sampler]='FIST'
+    touch "${HYBRID_fist_module[Particle_file]}" "${HYBRID_fist_module[Decays_file]}"
+    HYBRID_given_software_sections+=('Sampler')
+    HYBRID_software_executable[Sampler]="${HYBRIDT_tests_folder}/mocks/echo.py"
+    HYBRID_optional_feature[Add_spectators_from_IC]='FALSE'
+    Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
+}
+
+function Unit_Test__Afterburner-config-consistent-with-sampler-FIST()
+{
+    __static__Set_Events_Config_Key_For_Sampler_And_Run_Consistency_Check
+}
+
+function Clean_Tests_Environment_For_Following_Test__Afterburner-config-consistent-with-sampler-FIST()
+{
+    rm "${HYBRID_fist_module[Decays_file]}"
+    rm "${HYBRID_fist_module[Particle_file]}"
     rm -r "${HYBRID_output_directory}"
 }
 


### PR DESCRIPTION
This closes #77.  As already mentioned in the issue, I implemented a new unit test for FIST checking for the inconsistency in the event number comparison between sampler and afterburner and included the check for the FIST sampler to fix the bug.