### PR TITLE
Add new SMASH sampler config key that handles hydrodynamic simulations in Cartesian coordinates

### DIFF
--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -47,7 +47,7 @@ function Validate_Configuration_File_Of_SMASH()
         'ratio_pressure_energydensity'
     )
     if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.2'; then
-        allowed_keys+=('create_root_output')
+        allowed_keys+=('create_root_output' 'hydro_coordinate_system')
     fi
     readonly allowed_keys
     local keys_to_be_found
@@ -99,6 +99,14 @@ function Validate_Configuration_File_Of_SMASH()
                 if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
                     Print_Error 'Found non-integer value ' --emph "${value:-''}" \
                         ' for ' --emph "${key}" ' key.'
+                    return 1
+                fi
+                ;;
+            hydro_coordinate_system)
+                if [[ ! "${value}" =~ ^(tau-eta|cartesian)$ ]]; then
+                    Print_Error 'Found invalid value ' --emph "${value:-''}" \
+                        ' for key ' --emph "${key}" '.\nAllowed are only ' \
+                        --emph 'tau-eta' ' or ' --emph 'cartesian' '.'
                     return 1
                 fi
                 ;;

--- a/configs/hadron_sampler__ge_v3.2
+++ b/configs/hadron_sampler__ge_v3.2
@@ -7,3 +7,4 @@ shear                         1
 cs2                           0.15
 ratio_pressure_energydensity  0.15
 create_root_output            0
+hydro_coordinate_system       tau-eta

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -48,7 +48,9 @@ Given a version number `X.Y.Z`,
 
     **Changes:**
 
-    :new: The `Input_file` configuration key in the `Hydro` and `Afterburner` modules can now be used to modify the expected file names from the appropriate :file_folder: ***IC*** and :file_folder: ***Sampler*** sub-folders, when a string without a `/` character is given.
+    :new: &nbsp; Added new valid config key `hydro_coordinate_system` for SMASH sampler to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.
+
+    :new: &nbsp; The `Input_file` configuration key in the `Hydro` and `Afterburner` modules can now be used to modify the expected file names from the appropriate :file_folder: ***IC*** and :file_folder: ***Sampler*** sub-folders, when a string without a `/` character is given.
 
 
 ### SMASH-vHLLE-hybrid-2.1.3

--- a/docs/user/configuration_file.md
+++ b/docs/user/configuration_file.md
@@ -172,7 +172,7 @@ Sampler:
     Executable: /path/to/Hadron-sampler
     Config_file: /path/to/Hadron-sampler_config
     Software_keys:
-        surface: /path/to/custom/freezeout.dat
+        surface_file: /path/to/custom/freezeout.dat
 ```
 
 For the hadron sampler section, there is the additional option to use an alternative sampling software, the FIST sampler. By default, the SMASH-hadron-sampler is used.

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -267,7 +267,8 @@ function Unit_Test__Sampler-validate-config-file-SMASH()
         'shear true' \
         'cs2 +-1' \
         'ratio_pressure_energydensity +-1' \
-        'create_root_output True'; do
+        'create_root_output True' \
+        'hydro_coordinate_system +-1'; do
         __static__Validate_Given_Configuration_File_SMASH \
             "'${wrong_key_value}' should not be accepted" "${mandatory_config_keys[@]}" "${wrong_key_value}"
         __static__Possibly_Fail_Validation_Test $? || return 1


### PR DESCRIPTION
I introduced the new config key `hydro_coordinate_system` to the allowed SMASH-hadron-sampler config keys which specifies in which coordinate system the hydrodynamic simulation was run and hence the four-position of freeze-out hypersurface elements is provided. This new config key was introduced in sampler PR smash-transport/smash-hadron-sampler#54 (possible key values: `tau-eta` (default) and `cartesian`).

As soon as the vHLLE config key is introduced to set the coordinate system of the hydro stage, it might be worth to implement a check to the handler if the keys are equal in the hydro and sampler config sections when both stages are ran (with one handler config).

@RenHirayama and @zpauliny, this concludes the implementation of the proper sampler handling for the Cartesian vHLLE runs into the hybrid framework.