### PR TITLE
Remove bare exceptions in python files

### DIFF
--- a/python/add_spectators.py
+++ b/python/add_spectators.py
@@ -52,7 +52,7 @@ def get_initial_nucleons_from_config():
 
         for particle in target_particles.keys():
             N_initial_nucleons += target_particles[particle]
-    except:
+    except KeyError:
         print("The config file does not contain the necessary information "
               "about the projectile and/or target nuclei.")
         sys.exit(1)
@@ -73,7 +73,8 @@ def extract_spectators():
     spectator_list = []
     with open(args.initial_particle_list, 'r') as f:
         for line in f:
-            if line[0] == "#": continue  # Comment line
+            if len(line) == 0 or line[0] == "#":
+                continue  # Skip empty lines and comments
             # Is initial nucleon and has not interacted
             particle_id = int(line.split()[10])
             N_collisions = int(line.split()[12])
@@ -106,7 +107,7 @@ def write_full_particle_list(spectator_list):
     with open(args.sampled_particle_list, 'r') as sampler_output_file:
         for line in sampler_output_file:
             # Find header of each new event
-            if (line.startswith('# event') and ("out" in line) and (not "end" in line)):
+            if (line.startswith('# event') and ('out' in line) and ('end' not in line)):
                 # The string after 'out' contains the number of sampled particles for
                 # each event. The number of spectators needs to be added to this value.
                 partitioned_line = line.partition('out ')

--- a/python/test_requirement.py
+++ b/python/test_requirement.py
@@ -48,7 +48,7 @@ requirement = package_name + version_specifier
 
 try:
     from packaging.requirements import Requirement
-except:
+except ImportError:
     if package_name == 'packaging':
         print('---|---|---')
         exit(1)

--- a/tests/mocks/smash_afterburner_black-box.py
+++ b/tests/mocks/smash_afterburner_black-box.py
@@ -59,10 +59,10 @@ def run_smash(finalize,SMASH_input_file_with_participants_and_spectators,sampler
     # create smash.lock file
     f = open(args.o+file_name_is_running, "w")
     try:
-        f_in=open(sampler_dir+SMASH_input_file_with_participants_and_spectators,"r")
+        f_in = open(sampler_dir+SMASH_input_file_with_participants_and_spectators, "r")
         f_in.close()
         print("File read")
-    except:
+    except OSError:
         print(fatal_error+"Sampled particle list could not be opened")
         sys.exit(1)
     f.close()
@@ -106,25 +106,16 @@ def parse_command_line_config_options():
         data_config = yaml.safe_load(file)
 
     sampler_dir=""
-    dir_config=False
-    n_events_config=False
 
     try:
-        n_events=data_config['General']['Nevents']
-        n_events_config=True
-    except:
-        print("Nevents could not be parsed")
-        sys.exit(1)
-    try:
         sampler_dir=data_config['Modi']['List']['File_Directory']
-        dir_config=True
-    except:
+    except KeyError:
         print("File directory could not be parsed")
         sys.exit(1)
 
     try:
         file=data_config['Modi']['List']['Filename']
-    except:
+    except KeyError:
         print("Filename could not be parsed")
         sys.exit(1)
 

--- a/tests/mocks/vhlle_black-box.py
+++ b/tests/mocks/vhlle_black-box.py
@@ -44,7 +44,7 @@ def read_parameters(configFile):
         "etaSMin": ["etaSMin", 0],
         "T0": ["T0", 0],
         "eEtaSmin": ["eEtaSmin", 0],
-        "zetaS": ["zeta/s" , 0],
+        "zetaS": ["zeta/s", 0],
         "epsilon0": ["epsilon0", 0],
         "Rg": ["Rgt", 0],
         "Rgz": ["Rgz", 0],
@@ -60,7 +60,8 @@ def read_parameters(configFile):
         for line in open(configFile, "r"):
             line = line.split()
             for key in parameters:
-                if key in line: parameters[key][1] = line[1]
+                if key in line:
+                    parameters[key][1] = line[1]
     return parameters
 
 def print_parameters():
@@ -146,7 +147,7 @@ Init time = 9 [sec]"""
     if os.path.exists(args.ISinput) and input_is_valid:
         print(messageExample)
     else:
-        print("I/O error with",args.ISinput)
+        print("I/O error with", args.ISinput)
         sys.exit(1)
 
 def print_timestep(timestep):
@@ -163,14 +164,15 @@ def print_timestep(timestep):
 def run_hydro(outputDirSpecified):
     # create freezout hypersurface file
     # only if output directory is specified
-    if outputDirSpecified: freezeout = open(args.outputDir+"freezeout.dat", "w")
+    if outputDirSpecified:
+        freezeout = open(args.outputDir+"freezeout.dat", "w")
     variableList = ["tau", "E", "Efull", "Nb", "Sfull", "EtotSurf", "elements", "susp.", "%cut"]
     # run the black box
     print("{: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10}".format(*variableList))
     if crash:
         print("Crash happened in vHLLE")
         sys.exit(1)
-    for ts in range(1,13):
+    for ts in range(1, 13):
         print_timestep(ts)
         time.sleep(0.1)
     if outputDirSpecified:


### PR DESCRIPTION
This tackles the first half of #83, removing the bare `except` statements from the python files. Additionally, I did some minor cleanups here and there, ending up removing some redundant code in _tests/mocks/smash_afterburner_black-box.py_. The two variables `dir_config` and `n_events_config` were unused since the corresponding `if` statement
```python
if not (dir_config and n_events_config):
```
was removed in commit 4ce1e3d (see [line 161](https://github.com/smash-transport/smash-vhlle-hybrid/commit/4ce1e3dc8b8555a47024e3c626b9d6605f9a7662#diff-92f3ef6d37bf5f68af5893006886b73f0958ecec2c1fbbc7042260831b43a9a1L161)).

