### PR TITLE
Add DOI to main documentation page

### DIFF
--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SMASH-vHLLE-Hybrid
+# Hybrid-handler
 
 <img src="https://github.com/smash-transport/smash-vhlle-hybrid/blob/main/docs/images/logo.png" align="right" width="25%"/>
 

--- a/bash/Afterburner_functionality.bash
+++ b/bash/Afterburner_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/Hydro_functionality.bash
+++ b/bash/Hydro_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/Hydro_functionality.bash
+++ b/bash/Hydro_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -89,14 +89,14 @@ function __static__Create_Symbolic_Link_To_EOS_Folder()
                 exit_code=${HYBRID_fatal_logic_error} Print_Fatal_And_Exit \
                     'A ' --emph 'eos' ' folder called already exists at ' \
                     --emph "${HYBRID_software_output_directory[Hydro]}" \
-                    '.' 'Please remove it and run the hybrid handler again.'
+                    '.' 'Please remove it and run the Hybrid-handler again.'
             fi
         fi
     elif [[ -e "${link_to_eos_folder}" ]]; then
         exit_code=${HYBRID_fatal_logic_error} Print_Fatal_And_Exit \
             'A ' --emph 'eos' ' file already exists at ' \
             --emph "${HYBRID_software_output_directory[Hydro]}" \
-            '.' 'Please remove it and run the hybrid handler again.'
+            '.' 'Please remove it and run the Hybrid-handler again.'
     else
         ln -s "${eos_folder}" "${link_to_eos_folder}"
     fi

--- a/bash/IC_functionality.bash
+++ b/bash/IC_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/Sampler_functionality.bash
+++ b/bash/Sampler_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/Sampler_functionality_FIST.bash
+++ b/bash/Sampler_functionality_FIST.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/command_line_parsers/allowed_options.bash
+++ b/bash/command_line_parsers/allowed_options.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/command_line_parsers/helper.bash
+++ b/bash/command_line_parsers/helper.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -142,7 +142,7 @@ function __static__Print_Given_Command_Line_Option_Help()
             __static__Print_Command_Line_Option_Help \
                 '--id' "${HYBRID_run_id}" \
                 'Run ID to be used by the handler. The timestamp in the' \
-                'default value refers to when the hybrid handler is run.'
+                'default value refers to when the Hybrid-handler is run.'
             ;;
         *)
             Print_Internal_And_Exit \

--- a/bash/command_line_parsers/helper.bash
+++ b/bash/command_line_parsers/helper.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/command_line_parsers/main_parser.bash
+++ b/bash/command_line_parsers/main_parser.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/command_line_parsers/sub_parser.bash
+++ b/bash/command_line_parsers/sub_parser.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/common_functionality.bash
+++ b/bash/common_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/configuration_parser.bash
+++ b/bash/configuration_parser.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/configuration_parser.bash
+++ b/bash/configuration_parser.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -13,7 +13,7 @@
 function Validate_And_Parse_Configuration_File()
 {
     Ensure_Given_Files_Exist \
-        'A configuration file is needed to run the hybrid handler.' '--' \
+        'A configuration file is needed to run the Hybrid-handler.' '--' \
         "${HYBRID_configuration_file}"
     __static__Abort_If_Configuration_File_Is_Not_A_Valid_YAML_File
     __static__Abort_If_Sections_Are_Violating_Any_Requirement

--- a/bash/dispatch_functions.bash
+++ b/bash/dispatch_functions.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/error_codes.bash
+++ b/bash/error_codes.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/execution_mode_do.bash
+++ b/bash/execution_mode_do.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/execution_mode_prepare.bash
+++ b/bash/execution_mode_prepare.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -12,7 +12,7 @@ function Do_Needed_Operation_For_Parameter_Scan()
     # This array is going to contain a map between the parameter and its list
     # of values. Since in general a scan run could request a scan in parameters
     # of different stages, here the parameter name is stored as a period-separated
-    # list of keys as they appear in the Hybrid Handler configuration file, and
+    # list of keys as they appear in the Hybrid-handler configuration file, and
     # precisely in the 'Software_keys' sections. For example a scan in Hydro 'etaS'
     # would be stored here in the component with key 'Hydro.Software_keys.etaS'.
     # This syntax is handy when it comes to prepare all the configuration files

--- a/bash/execution_mode_prepare.bash
+++ b/bash/execution_mode_prepare.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/formatter.bash
+++ b/bash/formatter.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/global_variables.bash
+++ b/bash/global_variables.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/logger.bash
+++ b/bash/logger.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/progress_bar.bash
+++ b/bash/progress_bar.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/sanity_checks.bash
+++ b/bash/sanity_checks.bash
@@ -56,14 +56,14 @@ function __static__Set_Global_Variables_As_Readonly()
 function Perform_Internal_Sanity_Checks()
 {
     Internally_Ensure_Given_Files_Exist \
-        'These Python scripts should be shipped within the hybrid handler codebase.' '--' \
+        'These Python scripts should be shipped within the Hybrid-handler codebase.' '--' \
         "${HYBRID_external_python_scripts[@]}"
     for key in "${!HYBRID_software_base_config_file[@]}"; do
         # The IC/Sampler entry in the associative array here is still empty and does not point to a
         # shipped configuration file. It will be chosen later according to the verion or module.
         if [[ ! ${key} =~ ^(IC|Sampler)$ ]]; then
             Internally_Ensure_Given_Files_Exist \
-                'These base configuration files should be shipped within the hybrid handler codebase.' '--' \
+                'These base configuration files should be shipped within the Hybrid-handler codebase.' '--' \
                 "${HYBRID_software_base_config_file[${key}]}"
         fi
     done

--- a/bash/sanity_checks.bash
+++ b/bash/sanity_checks.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/scan_files_operations.bash
+++ b/bash/scan_files_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/scan_validation.bash
+++ b/bash/scan_validation.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/scan_validation.bash
+++ b/bash/scan_validation.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024-2025
 #      SMASH Hybrid Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -53,11 +53,11 @@ function Validate_And_Store_Scan_Parameters()
     done
     if [[ ${counter} -ne 0 ]]; then
         exit_code=${HYBRID_fatal_wrong_config_file} Print_Fatal_And_Exit \
-            '\nThe hybrid handler configuration file contains ' \
+            '\nThe Hybrid-handler configuration file contains ' \
             --emph "${counter}" ' invalid scan specifications.'
     elif [[ ${#list_of_parameters_values[@]} -eq 0 ]]; then
         exit_code=${HYBRID_fatal_wrong_config_file} Print_Fatal_And_Exit \
-            'The hybrid handler configuration file does not properly specify scan parameters.' \
+            'The Hybrid-handler configuration file does not properly specify scan parameters.' \
             'Make sure to specify the ' --emph 'Scan_parameters' ' key in the appropriate sections.'
     fi
 }

--- a/bash/scan_values_operations.bash
+++ b/bash/scan_values_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/software_input_functionality.bash
+++ b/bash/software_input_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/software_operations.bash
+++ b/bash/software_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/source_codebase_files.bash
+++ b/bash/source_codebase_files.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/system_requirements.bash
+++ b/bash/system_requirements.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/utility_functions.bash
+++ b/bash/utility_functions.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/bash/utility_functions.bash
+++ b/bash/utility_functions.bash
@@ -351,7 +351,7 @@ In particular:
     This function considers as comments anything coming after _any_ occurrence of
     the specified comment character and **you should not use it if there might
     be occurrences of that character that do not start a comment!**
-    For the hybrid handler configuration such a basic implementation is enough.
+    For the Hybrid-handler configuration such a basic implementation is enough.
 --8<-- [end:Remove_Comments_In_File-desc]
 --8<-- [start:Remove_Comments_In_File-ex]
 Remove_Comments_In_File 'config.yaml'

--- a/bash/version.bash
+++ b/bash/version.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to SMASH-vHLLE-Hybrid
+# Contributing to the Hybrid-handler
 
 If you landed here, you might be thinking of contributing to the codebase: **Excellent decision!** :upside_down_face:
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -51,7 +51,7 @@ Some guidance for authors is also provided here, in order to reach a coherent st
     #===================================================
     #
     #    Copyright (c) 2024
-    #      SMASH Hybrid Team
+    #      Hybrid-handler Team
     #
     #    GNU General Public License (GPLv3 or later)
     #

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -96,7 +96,7 @@ Any developer should be aware that, because of the nature of the Bash scripting 
 Therefore, it is crucial for the developer to stay consistent with the existing style and, more importantly, to take some minutes to read the following lists.
 In particular, be aware the the formatter will not enforce the rules explained below.
 
-!!! tip "The main hybrid handler script can format the codebase!"
+!!! tip "The main Hybrid-handler script can format the codebase!"
     Before opening a PR, make sure all tests pass.
     One of them will try to check formatting and complain if something has to be adjusted.
     The main script has a `format` execution mode which formats the full codebase and runs the formatting unit test.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -6,7 +6,7 @@ hide:
 
 # From great power comes great responsibility
 
-The hybrid handler has been developed trying to make the entry point of a newbie developer as low as possible.
+The Hybrid-handler has been developed trying to make the entry point of a newbie developer as low as possible.
 Although :simple-gnubash: **Bash** can be sometimes not that simple to read[^1], the integration-operation segregation principle ([IOSP](https://clean-code-developer.com/grades/grade-1-red/)) has been used most of the times at the the top-level to allow the reader to get a first understanding of what the main functions are doing, having then the possibility to deepen into lower levels if needed.
 Said differently, reading the code top-down should be straightforward, as the most top-level function is a series of function calls only, whose names should clearly describe what is done.
 

--- a/docs/developer/new_module.md
+++ b/docs/developer/new_module.md
@@ -1,6 +1,6 @@
 # Adding a new module
 
-Although the SMASH-vHLLE-hybrid, as implied in the name, was built with a defined set of software modules, it is designed to be easily extensible with new modules.
+Although the Hybrid-handler was built with a defined set of software modules, it is designed to be easily extensible with new modules.
 This allows, amongst other things, to test new algorithms and study model dependency.
 
 !!! tip "Take inspiration from the existing modules"
@@ -14,7 +14,7 @@ This allows, amongst other things, to test new algorithms and study model depend
     In this case the mentioned snippets of code are unlikely to be invalid at some point, but you should keep in mind that something might have to be done in a slightly different way.
     If so, you can take the opportunity to refine these instructions. :wink:
 
-Adding a new module to the SMASH-vHLLE-hybrid is a straightforward process.
+Adding a new module to the Hybrid-handler is a straightforward process.
 The following steps serve as a guidance and will probably be needed. Let's assume we want to add [MUSIC](https://github.com/MUSIC-fluid/MUSIC) as an alternative for the hydrodynamic stage:
 
 * In case the stage has no other modules, add a field to the `HYBRID_module` array in the :material-file: *global_variables.bash* script for the respective stage :material-information-outline:{ title="Here <mark style='background-color: #F0F0F0;'><tt>Hydro</tt></mark>"}.

--- a/docs/developer/parameters_scan.md
+++ b/docs/developer/parameters_scan.md
@@ -82,7 +82,7 @@ This might be done in a single swipe but would make it basically impossible to l
 Therefore the scan YAML maps are first stored and then used at a later point to produce the list of values of each parameter.
 
 A single Bash associative array has been chosen for this purpose.
-Its keys are the parameters stored as a period-separated list of YAML keys as they appear in the hybrid handler configuration file, and precisely in the 'Software_keys' sections.
+Its keys are the parameters stored as a period-separated list of YAML keys as they appear in the Hybrid-handler configuration file, and precisely in the 'Software_keys' sections.
 The value of each array entry is, in a first phase, the YAML scan map.
 Later, this is replaced by a string containing a list of parameter values.
 In this case a YAML sequence style is kept, i.e. with squares and commas.

--- a/docs/developer/testing_framework.md
+++ b/docs/developer/testing_framework.md
@@ -137,7 +137,7 @@ If such a function exists, the runner will check for existence of the correspond
 
 !!! tip "Use the framework functionality to invoke code to test"
     * Codebase functions to be invoked in unit tests should be called through the `Call_Codebase_Function` and `Call_Codebase_Function_In_Subshell` interface functions (passing the name of the function to be invoked as first argument and the arguments to be forward afterwards).
-    *  In functional tests you'll probably want to run the hybrid handler with some options and this can be easily achieved by using the `Run_Hybrid_Handler_With_Given_Options_In_Subshell` function.
+    *  In functional tests you'll probably want to run the Hybrid-handler with some options and this can be easily achieved by using the `Run_Hybrid_Handler_With_Given_Options_In_Subshell` function.
 
 !!! warning "Each test is run in its own subshell"
     The full test flow, including setup and teardown, is run in a subshell in order to isolate its changes from the external environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,19 +8,33 @@ hide:
 
 ![Image title](images/logo.png){ width="25%", align=right }
 
-Event-by-event hybrid model for the description of relativistic heavy-ion collisions in the low and high baryon-density regime. This model constitutes a chain of different submodules to appropriately describe each phase of the collision with its corresponding degrees of freedom. It consists of the following modules:
+Event-by-event hybrid model for the description of relativistic heavy-ion collisions in the low and high baryon-density regime.
+This model constitutes a chain of different submodules to appropriately describe each phase of the collision with its corresponding degrees of freedom.
+It consists of the following stages and supported software modules are listed within each stage:
 
-:cloud_tornado: &nbsp; **SMASH** hadronic transport approach to provide the initial conditions
+:cloud_tornado: &nbsp; **Initial conditions**
 
-:droplet: &nbsp; **vHLLE** 3+1D viscous hydrodynamics approach to describe the evolution of the hot and dense fireball
+:   :simple-ticktick: &nbsp; *SMASH* (hadronic transport approach)
 
-:   :material-arrow-right-bottom: &nbsp; CORNELIUS tool to construct a hypersurface of constant energy density from the hydrodynamical evolution (embedded in vHLLE)
+:droplet: &nbsp; **Hydrodynamics** to describe the evolution of the hot and dense fireball
 
-:seedling: &nbsp; **Sampler** to perform Cooper-Frye particlization of the elements on the freezeout hypersurface
+:   :simple-ticktick: &nbsp; *vHLLE* (3+1D viscous hydrodynamics approach)
+    :   :material-arrow-right-bottom: &nbsp; including *CORNELIUS* to construct a constant energy density hypersurface from the hydrodynamical evolution
 
-:fire: &nbsp; **SMASH** hadronic transport approach to perform the afterburner evolution
+:seedling: &nbsp; **Hadron sampler** to perform Cooper-Frye particlization of the elements on the freezeout hypersurface
 
-!!! info "Give credit appropriately"
+:   :simple-ticktick: &nbsp; *SMASH hadron sampler*
+:   :simple-ticktick: &nbsp; *FIST sampler*
 
-    If you are using the Hybrid-handler, please cite [Eur.Phys.J.A 58(2022)11,230](https://arxiv.org/abs/2112.08724).
-    You may also consult this reference for further details about the hybrid approach.
+:fire: &nbsp; **Afterburner** evolution
+
+:   :simple-ticktick: &nbsp; *SMASH* (hadronic transport approach)
+
+!!! info "Give credit appropriately &nbsp; [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15880337.svg){ align=right }](https://doi.org/10.5281/zenodo.15880337)"
+
+    If you are using the Hybrid-handler, please cite the corresponding [:simple-doi: software DOI](https://doi.org/10.5281/zenodo.15880337) of the specific code version employed.
+    Depending on the stages and modules you are using, please cite the appropriate papers and software DOIs as well.
+
+    For example, if you use the SMASH-vHLLE-hybrid approach, besides citing the Hybrid-handler itself, you should cite [:newspaper: Eur.Phys.J.A 58(2022)11, 230](https://arxiv.org/abs/2112.08724) for the physics aspects.
+    This paper can be also consulted for further details on the underlying physics.
+    Additionally, you should cite the individual software package used for each stage, i.e. SMASH, vHLLE, and the SMASH hadron sampler.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hide:
   - toc
 ---
 
-# SMASH-vHLLE-Hybrid
+# Hybrid-handler
 
 ![Image title](images/logo.png){ width="25%", align=right }
 
@@ -22,5 +22,5 @@ Event-by-event hybrid model for the description of relativistic heavy-ion collis
 
 !!! info "Give credit appropriately"
 
-    If you are using the SMASH-vHLLE-hybrid, please cite [Eur.Phys.J.A 58(2022)11,230](https://arxiv.org/abs/2112.08724).
+    If you are using the Hybrid-handler, please cite [Eur.Phys.J.A 58(2022)11,230](https://arxiv.org/abs/2112.08724).
     You may also consult this reference for further details about the hybrid approach.

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -1,4 +1,4 @@
-# Hybrid handler CHANGELOG
+# Hybrid-handler CHANGELOG
 
 All notable changes to this project will be documented in this changelog.
 This project does not strictly adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), but it uses versioning inspired by it.
@@ -58,14 +58,14 @@ Given a version number `X.Y.Z`,
 
 ???+ success "&nbsp; :date: &nbsp; Release date: 2025-06-05 &emsp; :left_right_arrow: &nbsp; [Compare changes to previous version](https://github.com/smash-transport/smash-vhlle-hybrid/compare/SMASH-vHLLE-hybrid-2.1.2...SMASH-vHLLE-hybrid-2.1.3)"
 
-    :sos: &nbsp; Fix hybrid handler crash due to accessing an unbound variable when trying to run both the `Sampler` and the `Afterburner` stages using the FIST sampler.
+    :sos: &nbsp; Fix Hybrid-handler crash due to accessing an unbound variable when trying to run both the `Sampler` and the `Afterburner` stages using the FIST sampler.
 
 
 ### SMASH-vHLLE-hybrid-2.1.2
 
 ???+ success "&nbsp; :date: &nbsp; Release date: 2025-05-16 &emsp; :left_right_arrow: &nbsp; [Compare changes to previous version](https://github.com/smash-transport/smash-vhlle-hybrid/compare/SMASH-vHLLE-hybrid-2.1.1...SMASH-vHLLE-hybrid-2.1.2)"
 
-    :sos: &nbsp; The previous hot-fix introduced a subtle bug, making the hybrid handler ignore a user-customized base configuration file for the `IC` stage. This is fixed now.
+    :sos: &nbsp; The previous hot-fix introduced a subtle bug, making the Hybrid-handler ignore a user-customized base configuration file for the `IC` stage. This is fixed now.
 
 
 ### SMASH-vHLLE-hybrid-2.1.1

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -48,6 +48,8 @@ Given a version number `X.Y.Z`,
 
     **Changes:**
 
+    :new: &nbsp; The name of the framework is changed from SMASH-vHLLE-hybrid to Hybrid-handler. Since the handler is a tool to facilitate running hybrid simulations and the underlying stage modules can be varied, this generic name is more precise. Nevertheless, the SMASH-vHLLE-hybrid approach is still part of this framework.
+
     :new: &nbsp; Added `Add_corona_from_IC_and_Hydro` configuration key in the `Afterburner` module, which merges the files containing corona particles from :file_folder: ***IC*** and :file_folder: ***Hydro*** into the particle lists sampled in :file_folder: ***Sampler***.
 
     :new: &nbsp; Added new valid config key `hydro_coordinate_system` for SMASH sampler to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.

--- a/docs/user/FAQ/index.md
+++ b/docs/user/FAQ/index.md
@@ -2,14 +2,14 @@
 
 ### How can I add a software key to a configuration file?
 
-Using the hybrid handler, many different programs are run and each of them needs a configuration file.
-The hybrid handler also needs a configuration file and having many of these might lead to some confusion.
+Using the Hybrid-handler, many different programs are run and each of them needs a configuration file.
+The Hybrid-handler also needs a configuration file and having many of these might lead to some confusion.
 
 All the configuration files of the separate software for each state _can_ be specified by the user, but *do not have to*.
-The hybrid handler is using default ones, which are shipped in the :file_folder: **configs** folder.
+The Hybrid-handler is using default ones, which are shipped in the :file_folder: **configs** folder.
 You can have a look to these files to see which keys are used there.
 
-Since using the `Software_keys` key in the hybrid handler configuration file it is only possible to **change** the value of an existing input key in the software configuration file, it would result in an error to attempt to add a missing one.
+Since using the `Software_keys` key in the Hybrid-handler configuration file it is only possible to **change** the value of an existing input key in the software configuration file, it would result in an error to attempt to add a missing one.
 Analogously, there is no mechanism to remove keys from the default base software configuration file used by the handler.
 
 Let's see in a concrete example how to proceed if different keys are needed.
@@ -57,7 +57,7 @@ The following setup would not work, as the `Use_Grid` key in the `General` secti
             Filename: "sampled_particles.oscar"
     ```
 
-The correct way to fix the problem is to create a new SMASH afterburner configuration file, having all the keys that need to be modified and then modify them from the hybrid handler configuration file **after having specified that a custom configuration file should be used for the afterburner stage**.
+The correct way to fix the problem is to create a new SMASH afterburner configuration file, having all the keys that need to be modified and then modify them from the Hybrid-handler configuration file **after having specified that a custom configuration file should be used for the afterburner stage**.
 
 === "Hybrid-handler configuration file"
     ``` {.yaml .annotate}
@@ -97,7 +97,7 @@ The correct way to fix the problem is to create a new SMASH afterburner configur
     In complex projects it might be handy to prepare base configuration files for the needed stages in the beginning.
     A good idea might be to keep them close to the data in a known, dedicated folder.
     This ensures reproducibility at any point during the project and can be seen as a good data management practice.
-    Of course, you will need to point to your custom base configuration files from within the hybrid handler configuration file in the different stages blocks.
+    Of course, you will need to point to your custom base configuration files from within the Hybrid-handler configuration file in the different stages blocks.
 
     ``` { .bash .no-copy }
     📂 Project-directory
@@ -116,12 +116,12 @@ The correct way to fix the problem is to create a new SMASH afterburner configur
     </div>
 
 !!! danger "Do not edit the shipped base configuration file!"
-    Although this might be a quick way to try out something, you should never prefer to change the base configuration files in the hybrid handler repository.
+    Although this might be a quick way to try out something, you should never prefer to change the base configuration files in the Hybrid-handler repository.
     Your changes might get in conflict with future releases of the software or simply be undone by accident using Git inside the repository.
 
 ### Can I collide particles other than nuclei in the IC stage?
 
-You might have tried to use SMASH as initial-conditions software specifying a pion as the projectile via the following configuration file, but this was not accepted by the hybrid handler.
+You might have tried to use SMASH as initial-conditions software specifying a pion as the projectile via the following configuration file, but this was not accepted by the Hybrid-handler.
 
 ``` {.yaml .annotate title="Hybrid-handler configuration file"}
 IC:
@@ -145,7 +145,7 @@ Check out [this other question](#how-can-i-add-a-software-key-to-a-configuration
 
 ### How can I repeat the same run in parallel to increase statistics?
 
-The output folder in `do` mode is built by the hybrid handler in a way such that runs with different IDs do not interfere.
+The output folder in `do` mode is built by the Hybrid-handler in a way such that runs with different IDs do not interfere.
 Therefore, the same run can be repeated as many times as desired, on constraint that the user specifies a different run ID for each run.
 By default, the run ID contain a time stamp and, therefore, waiting at least one second before starting different instances of the same run and using the default run ID should achieve what desired.
 

--- a/docs/user/configuration_file.md
+++ b/docs/user/configuration_file.md
@@ -60,7 +60,7 @@ However, **it is strongly encouraged to exclusively use absolute paths** as rela
     Refer to the [:material-arrow-right-box: `Software_keys`](configuration_file.md#Software-keys) description for further information.
 
 !!! info "Enforced sanity rules"
-    Since the hybrid handler understands which software should be run from the presence of the corresponding section, there are a couple of totally natural rules that are enforced and will make the handler fail if violated.
+    Since the Hybrid-handler understands which software should be run from the presence of the corresponding section, there are a couple of totally natural rules that are enforced and will make the handler fail if violated.
 
     1. At least one software section must be present in the configuration file.
     2. Software sections must be specified in order and without gaps.
@@ -143,7 +143,7 @@ IC:
     This is the main output of the previous stage and, therefore, if not specified, a :material-file: *SMASH_IC.dat* file is expected to exist in the :file_folder: ***IC*** output sub-folder with the same `Run_ID`.
 
     However, using this key, any file can be specified and used.
-    If the key is a simple file name (without any `/`), the hybrid handler looks for this name in the corresponding :file_folder: ***IC*** output sub-folder, but if it is a path (i.e. it contains a `/`), that specific file will be used.
+    If the key is a simple file name (without any `/`), the Hybrid-handler looks for this name in the corresponding :file_folder: ***IC*** output sub-folder, but if it is a path (i.e. it contains a `/`), that specific file will be used.
 
 ```yaml title="Example"
 Hydro:
@@ -159,11 +159,11 @@ Hydro:
 ## :seedling: &nbsp; The hadron sampler section
 
 Also the hadron sampler needs in input the freezeout surface file, which is produced at the previous hydrodynamics stage.
-However, there is no dedicated `Input_file` key in the hadron sampler section of the hybrid handler configuration file, because the hadron sampler must receive the path to this file in its own configuration file already.
+However, there is no dedicated `Input_file` key in the hadron sampler section of the Hybrid-handler configuration file, because the hadron sampler must receive the path to this file in its own configuration file already.
 Therefore, the user can set any path to the freezeout surface file by specifying it in the `Software_keys` subsection, as shown in the example below.
 
-By default, if the user does not use a custom configuration file for the hadron sampler and does not specify the path to the freezeout surface file via `Software_keys`, the hybrid handler will use the configuration file for the hadron sampler which is contained in the :file_folder: ***configs*** folder and in which the path to the freezeout surface is set to `=DEFAULT=`.
-This will be internally resolved by the hybrid handler to the path of a :material-file: *freezeout.dat* file in the :file_folder: ***Hydro*** output sub-folder with the same `Run_ID`,  which is expected to exist.
+By default, if the user does not use a custom configuration file for the hadron sampler and does not specify the path to the freezeout surface file via `Software_keys`, the Hybrid-handler will use the configuration file for the hadron sampler which is contained in the :file_folder: ***configs*** folder and in which the path to the freezeout surface is set to `=DEFAULT=`.
+This will be internally resolved by the Hybrid-handler to the path of a :material-file: *freezeout.dat* file in the :file_folder: ***Hydro*** output sub-folder with the same `Run_ID`,  which is expected to exist.
 A mechanism like this one is technically needed to be able by default to refer to the same run ID and pick up the correct file from the previous stage.
 As a side-effect, it is not possible for the user to name the freezeout surface file as `=DEFAULT=`, which anyways would not probably be a very clever choice. :sweat_smile:
 
@@ -213,7 +213,7 @@ Sampler:
     As other stages, the afterburner run needs an additional input file as well, one which contains the sampled particles list.
     This is the main output of the previous sampler stage and, therefore, if not specified, a *particle_lists.oscar* file is expected to exist in the ***Sampler*** output sub-folder with the same `Run_ID`.
 
-    However, using this key, any file can be specified and used. If the key is a simple file name (without any `/`), the hybrid handler looks for this name in the corresponding :file_folder: ***Sampler*** output sub-folder, but if it is a path (i.e. it contains a `/`), that specific file will be used.
+    However, using this key, any file can be specified and used. If the key is a simple file name (without any `/`), the Hybrid-handler looks for this name in the corresponding :file_folder: ***Sampler*** output sub-folder, but if it is a path (i.e. it contains a `/`), that specific file will be used.
 
     :warning: Note that although it is possible to specify the input for the list modus in SMASH via the `Software_keys`, this is not allowed here and will result in an error.
     Always specify the customized input file for the afterburner stage using this key, if needed.
@@ -249,9 +249,9 @@ Afterburner:
 
 1. :bulb: If this key does not contain a `/` and is for example specified as `My_Sampler.out`, then the `Sampler` stage output file will take the specified name and it will be used as input for the `Afterburner` stage.
 
-## An example of a complete hybrid handler configuration file
+## An example of a complete Hybrid-handler configuration file
 
-If you wish to run a simulation of the full model using the default behavior of all the stages of the hybrid handler, then the following configuration file can be used.
+If you wish to run a simulation of the full model using the default behavior of all the stages of the Hybrid-handler, then the following configuration file can be used.
 
 ```yaml title="Example"
 IC:

--- a/docs/user/docker_image.md
+++ b/docs/user/docker_image.md
@@ -1,8 +1,8 @@
 # An Ubuntu-based framework
 
-Next to the hybrid handler repository, a Docker image based on Ubuntu to compile all SMASH-vHLLE-hybrid software and use the hybrid handler [is available](https://github.com/smash-transport/smash-vhlle-hybrid/pkgs/container/smash-vhlle-hybrid).
+Next to the Hybrid-handler repository, a Docker image based on Ubuntu to compile all SMASH-vHLLE-hybrid software and use the Hybrid-handler [is available](https://github.com/smash-transport/smash-vhlle-hybrid/pkgs/container/smash-vhlle-hybrid).
 Feel free to download it and use it.
-In the container all prerequisites of the hybrid handler are satisfied and the user can easily use it.
+In the container all prerequisites of the Hybrid-handler are satisfied and the user can easily use it.
 The image does not contain the supported software and its installation is left to the user.
 However, most libraries are available in the image an a list of them can be obtained inspecting the container.
 ```console title="A possible output of docker inspect"

--- a/docs/user/execution_modes.md
+++ b/docs/user/execution_modes.md
@@ -1,4 +1,4 @@
-# The hybrid handler
+# The Hybrid-handler
 
 Every operation can be done simply by running the :simple-gnubash: `Hybrid-handler` executable.
 This has different execution modes and most of them can be invoked with the `--help` option to get specific documentation of such a mode.
@@ -7,7 +7,7 @@ This has different execution modes and most of them can be invoked with the `--h
 ./Hybrid-handler do --help
 ```
 
-Each run of the hybrid handler (apart from auxiliary execution modes) makes use of a configuration file and it is the user responsibility to provide one.
+Each run of the Hybrid-handler (apart from auxiliary execution modes) makes use of a configuration file and it is the user responsibility to provide one.
 Few further customizations are possible using command line options, which are documented in the helper of each execution mode.
 
 !!! tip "A :fontawesome-brands-square-git: inspired user interface"
@@ -32,12 +32,12 @@ Few further customizations are possible using command line options, which are do
     ```
     ./Hybrid-handler version
     ```
-    The hybrid handler can be asked to print its version.
+    The Hybrid-handler can be asked to print its version.
     This might be particularly useful to store the handler version as metadata for reproducibility reasons.
-    As many Unix OS tools support a `--version` command line option, an alias for this mode has been added and the hybrid handler can be run with the `--version` command line option, too.
+    As many Unix OS tools support a `--version` command line option, an alias for this mode has been added and the Hybrid-handler can be run with the `--version` command line option, too.
 
     ??? question "Why do I just get a warning when asking the version?"
-        If for some reason you are not on tagged version of the codebase (e.g. you checked out a different commit), then you will be warned by the hybrid handler that you are not using an official release.
+        If for some reason you are not on tagged version of the codebase (e.g. you checked out a different commit), then you will be warned by the Hybrid-handler that you are not using an official release.
         This is meant to raise awareness, as it is encouraged to use stable versions only, especially for physics projects.
 
 
@@ -72,7 +72,7 @@ This might differ depending on how the used [handler configuration file](configu
 ## The `prepare-scan` execution mode
 
 This is a different mode, which per se won't run any simulation.
-Instead, the hybrid handler will prepare future runs by creating configuration files in a sub-folder of the output folder.
+Instead, the Hybrid-handler will prepare future runs by creating configuration files in a sub-folder of the output folder.
 The user can use the `--scan-name` command line option to provide a label to the scan, which will name the output sub-folder and will be used as filename prefix.
 For example, using the default generic `scan` name, the user will obtain the following tree folder.
 ```  { .bash .no-copy }
@@ -86,7 +86,7 @@ For example, using the default generic `scan` name, the user will obtain the fol
 
 <div class="grid cards" markdown>
 
-- :material-hammer-wrench: The scan parameters must be properly defined in the hybrid handler configuration file using [a dedicated syntax](scans_syntax.md).
+- :material-hammer-wrench: The scan parameters must be properly defined in the Hybrid-handler configuration file using [a dedicated syntax](scans_syntax.md).
 
 - :material-graph: How the parameters combinations are made is described in the documentation of the different [types of scans](scans_types.md).
 
@@ -95,7 +95,7 @@ For example, using the default generic `scan` name, the user will obtain the fol
 !!! note "Some useful remarks"
     The :material-file: *`scan_combinations.dat`* file will contain a list of all parameters combinations in a easily parsable table.
 
-    The :material-file: *`scan_run_*.yaml`* files are configuration files for the hybrid handler to run physics simulations.
+    The :material-file: *`scan_run_*.yaml`* files are configuration files for the Hybrid-handler to run physics simulations.
     For reproducibility reasons as well as to keep track that they belong to a scan, the scan name and parameters are printed in the beginning in commented lines.
     These files will have leading zeroes in the run index contained in the filename, depending on the total number of prepared simulations.
     This allows to keep them easily sorted.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -6,7 +6,7 @@ hide:
 
 # A unique wonderful tool
 
-The hybrid handler is a :simple-gnubash: **Bash script** and therefore it does not need any installation.
+The Hybrid-handler is a :simple-gnubash: **Bash script** and therefore it does not need any installation.
 Once cloned the repository, you can simply run the `Hybrid-handler` script[^1].
 
 [^1]: Be aware, that this might not work straightaway if only a very old Bash installation is available on your OS.
@@ -28,13 +28,13 @@ Once cloned the repository, you can simply run the `Hybrid-handler` script[^1].
 
     Everything can be done using a handy script with different execution modes.
 
-    [:material-arrow-right-box:&nbsp; The hybrid handler main script](execution_modes.md)
+    [:material-arrow-right-box:&nbsp; The Hybrid-handler main script](execution_modes.md)
 
 -   :screwdriver:{ .lg .middle } &nbsp; __Wanna run?__
 
     ---
 
-    Build your configuration file to use the hybrid handler according to your needs.
+    Build your configuration file to use the Hybrid-handler according to your needs.
 
     [:material-arrow-right-box:&nbsp; The configuration file](configuration_file.md)
 

--- a/docs/user/predefined_configs.md
+++ b/docs/user/predefined_configs.md
@@ -1,7 +1,7 @@
 # The predefined configuration files
 
 ## Configuring the collision setups
-There are several complete handler configuration files prepared for the user to run the hybrid handler in its entirety for different collision systems and energies. They follow the setup chosen in [:newspaper: *Schäfer et al.: Eur.Phys.J.A 58 (2022) 11, 230*](https://link.springer.com/article/10.1140/epja/s10050-022-00872-x). However, the finer hydrodynamic grid is by default commented out and has to be uncommented to reproduce the same setup as in the publication.
+There are several complete handler configuration files prepared for the user to run the Hybrid-handler in its entirety for different collision systems and energies. They follow the setup chosen in [:newspaper: *Schäfer et al.: Eur.Phys.J.A 58 (2022) 11, 230*](https://link.springer.com/article/10.1140/epja/s10050-022-00872-x). However, the finer hydrodynamic grid is by default commented out and has to be uncommented to reproduce the same setup as in the publication.
 The shear viscosities applied are taken from [:newspaper: *Karpenko et al.: Phys.Rev.C 91 (2015)*](https://journals.aps.org/prc/abstract/10.1103/PhysRevC.91.014906) and the longitudinal and transversal smearing parameters are adjusted to improve agreement with experimental data.
 The supported collision systems are listed in the following table.
 
@@ -22,7 +22,7 @@ The supported collision systems are listed in the following table.
 They can be found in :file_folder: **configs/predef_configs** folder and the user is only required to insert the paths of the executables in the individual software sections.
 They can be executed in the standard manner using `-c` option in the execution mode of the handler.
 
-``` title="Example about running hybrid handler for a predefined setup: Au+Au collision @ 4.3 GeV"
+``` title="Example about running Hybrid-handler for a predefined setup: Au+Au collision @ 4.3 GeV"
 ./Hybrid-handler do -c configs/predef_configs/config_AuAu_4.3.yaml
 ```
 
@@ -38,7 +38,7 @@ They can be executed in the standard manner using `-c` option in the execution m
 
 ## Running a test setup
 
-To test the functionality and to also run it on a local computer, there is the possibility to execute a test setup of the hybrid handler, which is a Au+Au collision at $\small\sqrt{s} = 7.7\;\mathrm{GeV}$.
+To test the functionality and to also run it on a local computer, there is the possibility to execute a test setup of the Hybrid-handler, which is a Au+Au collision at $\small\sqrt{s} = 7.7\;\mathrm{GeV}$.
 The statistics are significantly reduced and the grid for the hydrodynamic evolution is characterized by large cells, too large for a realistic simulation scenario.
 
 !!! danger "Don't use this setup for production!"
@@ -46,6 +46,6 @@ The statistics are significantly reduced and the grid for the hydrodynamic evolu
 
 To execute the test, a predefined configuration file is prepared in the same :file_folder: **predef_configs** folder. Again, the user needs to insert the paths to the executables in all the software sections.
 
-``` title="Example about running the test setup of the hybrid handler"
+``` title="Example about running the test setup of the Hybrid-handler"
 ./Hybrid-handler do -c configs/predef_configs/config_TEST.yaml
 ```

--- a/docs/user/prerequisites.md
+++ b/docs/user/prerequisites.md
@@ -1,11 +1,11 @@
-# Hybrid handler prerequisites
+# Hybrid-handler prerequisites
 
 ## Simulation software
 
 !!! info "Be aware about the meaning of the version requirements"
     In the following we state a version requirement for the external software needed in the various phases.
-    Strictly speaking, this is not a requirement for the hybrid handler, which most likely will correctly work even if different versions of the physics software are used.
-    However, the hybrid handler makes use of some default configuration files for each software and this does rely on the version of the given software.
+    Strictly speaking, this is not a requirement for the Hybrid-handler, which most likely will correctly work even if different versions of the physics software are used.
+    However, the Hybrid-handler makes use of some default configuration files for each software and this does rely on the version of the given software.
     Said differently, if you e.g. need to use older versions of some software, expect to have to specify a different base configuration for that given software [:material-arrow-right-box: configuration keys documentation](configuration_file.md#Config-file).
 
 <div class="grid" markdown>
@@ -31,7 +31,7 @@
 [^1]: Version `3.1` is only needed for the afterburner functionality. Otherwise version `1.8` is sufficient.
 [^2]:
     As SMASH is a dependency of the hadron sampler codebase, different versions of the latter have to be compiled with corresponding given versions of SMASH.
-    However, if you need to use a different version of the hadron sampler software, this is probably not making a difference from the Hybrid handler perspective and it is likely to work.
+    However, if you need to use a different version of the hadron sampler software, this is probably not making a difference from the Hybrid-handler perspective and it is likely to work.
 
 Instructions on how to compile or install the software above can be found at the provided links either in the official documentation or in the corresponding README files.
 
@@ -40,7 +40,7 @@ Instructions on how to compile or install the software above can be found at the
     We particularly highlight that the newer versions of ROOT require C++17 bindings or higher, which calls for proper treatment of compiler options in SMASH and the hadron sampler.
     It is also recommended to start from a clean build directory whenever changing the compiler or linking to external libraries that were compiled with different compiler flags.
 
-In principle, the Hybrid handler is agnostic to the physics model used in each state, and is built in a way to support different software with minimal efforts.
+In principle, the Hybrid-handler is agnostic to the physics model used in each state, and is built in a way to support different software with minimal efforts.
 Currently, this is realized for some of the different stages and the supported software is reported here below.
 
 ### Hadron Sampler
@@ -57,7 +57,7 @@ Currently, this is realized for some of the different stages and the supported s
 
 ## Unix system requirements
 
-The hybrid handler makes use of many tools which are usually installed on Unix systems.
+The Hybrid-handler makes use of many tools which are usually installed on Unix systems.
 For some of them a minimum version is required and for the others their availability is enough.
 However, in some cases, the GNU version is required and on some Linux distribution or on Apple machines the default installation might not be suitable.
 To check out what is required and what is available on your system, simply run the `Hybrid-handler` executable without options: An overview of the main functionality as well as a system requirements overview will be produced.
@@ -68,7 +68,7 @@ To check out what is required and what is available on your system, simply run t
     However, on Apple machines, the [`brew` package manager](https://brew.sh) can be easily used to install the possibly missing utilities.
 
     Please, note that the needed commands must be available and automatically findable by your bash shell.
-    For example, installing GNU AWK via `brew install gawk` is not enough as, by default, it only provides the `gawk` command and the hybrid handler needs `awk` instead.
+    For example, installing GNU AWK via `brew install gawk` is not enough as, by default, it only provides the `gawk` command and the Hybrid-handler needs `awk` instead.
     You then need to adjust the `PATH` environment variable as suggested by `brew` itself:
     ```bash
     export PATH="${HOMEBREW_PREFIX}/opt/gawk/libexec/gnubin:${PATH}"
@@ -83,8 +83,8 @@ To check out what is required and what is available on your system, simply run t
     The handler uses Python itself to check Python requirements and it needs to use the `packaging` module to do so.
     Make sure to have it available before starting, otherwise the handler will produce a non-fatal error mentioning this aspect.
 
-Few standalone Python scripts are used for dedicated tasks and this implies that the hybrid handler will terminate with an error if some of these requirements are missing.
-However, since not all requirements are *always* needed, the hybrid handler will only check for some of them on a per-run basis.
+Few standalone Python scripts are used for dedicated tasks and this implies that the Hybrid-handler will terminate with an error if some of these requirements are missing.
+However, since not all requirements are *always* needed, the Hybrid-handler will only check for some of them on a per-run basis.
 In the system overview obtained by running the `Hybrid-handler` executable without options, also Python requirements are listed, each with a short description about when such a requirement is needed.
 
 !!! question "I simply want to install all requirements. What should I do?"

--- a/docs/user/prerequisites.md
+++ b/docs/user/prerequisites.md
@@ -7,16 +7,17 @@
     Strictly speaking, this is not a requirement for the Hybrid-handler, which most likely will correctly work even if different versions of the physics software are used.
     However, the Hybrid-handler makes use of some default configuration files for each software and this does rely on the version of the given software.
     Said differently, if you e.g. need to use older versions of some software, expect to have to specify a different base configuration for that given software [:material-arrow-right-box: configuration keys documentation](configuration_file.md#Config-file).
+    Be aware that the mentioned physics software is merely the default and other options for a certain stage might be available, e.g. for the [sampler stage](#hadron-sampler).
 
 <div class="grid" markdown>
 <div class="center-table" markdown>
 
-| Physics Software | Suggested version |
-| :--------------: | :---------------: |
+| Physics software (default options) | Suggested version |
+| :--------------------------------: | :---------------: |
 | [SMASH](https://github.com/smash-transport/smash) | 3.1 or higher[^1] |
 | [vHLLE](https://github.com/yukarpenko/vhlle) | Tag `vhlle-smash-hybrid-1` |
 | [vHLLE parameters](https://github.com/yukarpenko/vhlle_params) | Tag `vhlle-smash-hybrid-1` |
-| [Hadron sampler](https://github.com/smash-transport/smash-hadron-sampler) | See below |
+| [SMASH hadron sampler](https://github.com/smash-transport/smash-hadron-sampler) | [See below](#hadron-sampler) |
 
 </div>
 <div class="center-table" markdown>
@@ -43,13 +44,13 @@ Instructions on how to compile or install the software above can be found at the
 In principle, the Hybrid-handler is agnostic to the physics model used in each state, and is built in a way to support different software with minimal efforts.
 Currently, this is realized for some of the different stages and the supported software is reported here below.
 
-### Hadron Sampler
+### Hadron sampler
 
 <div class="center-table" markdown>
 
-| Supported Software | Required version |
-| :------------: | :--------------: |
-| [Hadron sampler](https://github.com/smash-transport/smash-hadron-sampler) | Same as SMASH[^2] |
+| Supported software | Required version |
+| :----------------: | :--------------: |
+| [SMASH hadron sampler](https://github.com/smash-transport/smash-hadron-sampler) | Same as SMASH[^2] |
 | [FIST sampler](https://github.com/vlvovch/fist-sampler) | Commit `af99229` or later |
 
 </div>

--- a/docs/user/scans_syntax.md
+++ b/docs/user/scans_syntax.md
@@ -1,10 +1,10 @@
 # The parameters scan syntax
 
-In order to properly run the hybrid handler in `prepare-scan` mode, the configuration file must be properly created and fulfil few additional constraints.
+In order to properly run the Hybrid-handler in `prepare-scan` mode, the configuration file must be properly created and fulfil few additional constraints.
 
 !!! danger "Do not forget to declare scan parameters as such!"
     Each parameter which must be scanned has to be declared so by using the `Scan_parameters` key in the corresponding stage section [:material-arrow-right-box: key description](configuration_file.md#scan-parameters).
-    **If a parameter is not declared to be scanned** and is specified as a scan in the `Software_keys` section, this will probably not be caught by the hybrid handler and **the produced configurations are likely to be wrong**.
+    **If a parameter is not declared to be scanned** and is specified as a scan in the `Software_keys` section, this will probably not be caught by the Hybrid-handler and **the produced configurations are likely to be wrong**.
 
 !!! warning "Only scanning numerical parameters is possible"
     At the moment, it is not possible to scan parameters whose value is not numerical.

--- a/docs/user/scans_types.md
+++ b/docs/user/scans_types.md
@@ -56,7 +56,7 @@ For example, specifying two different scan parameters with 2 and 5 values, respe
     ```
 
 ??? question "What happens if I provide a single value for a scan parameter?"
-    If you provide a single-value list to `Values`, this will be accepted by the hybrid handler and the provided value will be considered in all combinations.
+    If you provide a single-value list to `Values`, this will be accepted by the Hybrid-handler and the provided value will be considered in all combinations.
     If this happen to be the only provided scan parameter, a single configuration file will be created together with a basically useless single-combination file. :sweat_smile:
 
 ### Latin Hypercube Sampling

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@
 # of most of the setup done here (cf. in particular the 'Setup' and 'Reference'
 # tabs in the documentation).
 
-site_name: SMASH-vHLLE-Hybrid
+site_name: Hybrid-handler
 copyright: Copyright &copy; 2024-2025 - SMASH team
 
 repo_url: https://github.com/smash-transport/smash-vhlle-hybrid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #
@@ -12,7 +12,7 @@
 # tabs in the documentation).
 
 site_name: Hybrid-handler
-copyright: Copyright &copy; 2024-2025 - SMASH team
+copyright: Copyright &copy; 2024-2025 - Hybrid-handler Team
 
 repo_url: https://github.com/smash-transport/smash-vhlle-hybrid
 repo_name: 'Repository'

--- a/python/add_corona.py
+++ b/python/add_corona.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #
@@ -122,8 +122,8 @@ def read_sampled_and_write_full_particle_list(args, corona_particles, n_events_i
                 corona_filter = corona_particles[corona_particles[:, 0] == str(event_c)]
                 particle_number = len(corona_filter)+len(sampled_particles)
                 with open(output_file, 'a') as f:
-                    f.write("# event {} out {}\n".format(event_s,particle_number)) 
-                    np.savetxt(f, sampled_particles, delimiter=' ', fmt='%s')   # write sampled 
+                    f.write("# event {} out {}\n".format(event_s,particle_number))
+                    np.savetxt(f, sampled_particles, delimiter=' ', fmt='%s')   # write sampled
                     np.savetxt(f, corona_filter[:,1:], delimiter=' ', fmt='%s') # write corona
                     f.write("# event {} end\n".format(event_s))
                 # reset relevant variables

--- a/python/add_spectators.py
+++ b/python/add_spectators.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/python/latin_hypercube_sampling.py
+++ b/python/latin_hypercube_sampling.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-# This file contains all python requirements that the hybrid handler needs in
+# This file contains all python requirements that the Hybrid-handler needs in
 # all its functionality. Some of them are not always needed and, therefore, the
 # system requirements check does not always require them all. Note that python
 # code is also used hard-coded via 'python -c' in some places in Bash code and

--- a/python/test_requirement.py
+++ b/python/test_requirement.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/command_line_parser_for_tests.bash
+++ b/tests/command_line_parser_for_tests.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests.bash
+++ b/tests/functional_tests.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_Afterburner_only.bash
+++ b/tests/functional_tests_Afterburner_only.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_Hydro_only.bash
+++ b/tests/functional_tests_Hydro_only.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_IC_only.bash
+++ b/tests/functional_tests_IC_only.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_Sampler_only.bash
+++ b/tests/functional_tests_Sampler_only.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_full_workflow.bash
+++ b/tests/functional_tests_full_workflow.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_help.bash
+++ b/tests/functional_tests_help.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_id_from_command_line.bash
+++ b/tests/functional_tests_id_from_command_line.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/functional_tests_version.bash
+++ b/tests/functional_tests_version.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/integration_tests.bash
+++ b/tests/integration_tests.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/integration_tests_custom_base_configuration.bash
+++ b/tests/integration_tests_custom_base_configuration.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/integration_tests_custom_inputfile.bash
+++ b/tests/integration_tests_custom_inputfile.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/mocks/echo.py
+++ b/tests/mocks/echo.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/mocks/sampler_black-box.py
+++ b/tests/mocks/sampler_black-box.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/mocks/smash_IC_black-box.py
+++ b/tests/mocks/smash_IC_black-box.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/mocks/smash_afterburner_black-box.py
+++ b/tests/mocks/smash_afterburner_black-box.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/mocks/vhlle_black-box.py
+++ b/tests/mocks/vhlle_black-box.py
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/tests_runner
+++ b/tests/tests_runner
@@ -3,7 +3,7 @@
 #===================================================
 #
 #    Copyright (c) 2023
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests.bash
+++ b/tests/unit_tests.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_Afterburner_functionality.bash
+++ b/tests/unit_tests_Afterburner_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_Hydro_functionality.bash
+++ b/tests/unit_tests_Hydro_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_IC_functionality.bash
+++ b/tests/unit_tests_IC_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_command_line_parser.bash
+++ b/tests/unit_tests_command_line_parser.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_configuration.bash
+++ b/tests/unit_tests_configuration.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_formatting.bash
+++ b/tests/unit_tests_formatting.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_help_for_user.bash
+++ b/tests/unit_tests_help_for_user.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_scan_files_operations.bash
+++ b/tests/unit_tests_scan_files_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_scan_validation.bash
+++ b/tests/unit_tests_scan_validation.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_scan_values_operations.bash
+++ b/tests/unit_tests_scan_values_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_software_input_functionality.bash
+++ b/tests/unit_tests_software_input_functionality.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_software_operations.bash
+++ b/tests/unit_tests_software_operations.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_system_requirements.bash
+++ b/tests/unit_tests_system_requirements.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_utility_functions.bash
+++ b/tests/unit_tests_utility_functions.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/unit_tests_version.bash
+++ b/tests/unit_tests_version.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2024
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/utility_functions.bash
+++ b/tests/utility_functions.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/utility_functions_functional.bash
+++ b/tests/utility_functions_functional.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2023-2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/utility_functions_integration.bash
+++ b/tests/utility_functions_integration.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #

--- a/tests/utility_functions_unit.bash
+++ b/tests/utility_functions_unit.bash
@@ -1,7 +1,7 @@
 #===================================================
 #
 #    Copyright (c) 2025
-#      SMASH Hybrid Team
+#      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #


### PR DESCRIPTION
This closes #81. @AxelKrypton, since these are quite a lot of changes, it might be easier to go through the commits one by one. For this purpose, I grouped similar changes into a commit, e.g., all the changes from `hybrid handler` to `Hybrid-handler` are in one commit and nothing else is changed.