### PR TITLE
Bump numpy version to `numpy~=2.0` and add missing copyright statements for python mock files

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,6 +5,6 @@
 # some of the following requirements are a direct consequence of that.
 
 packaging>=17.0
-numpy~=1.11
+numpy~=2.0
 PyYAML~=6.0.1
 pyDOE~=0.3.8

--- a/python/test_requirement.py
+++ b/python/test_requirement.py
@@ -58,7 +58,7 @@ except ImportError:
 
 if os.environ.get('HYBRID_TEST_MODE') is not None:
     # Mock pip, useful in handler unit tests
-    installed_packages = {"packaging": "24", "numpy": "1.26.4", "pyDOE": "", "PyYAML": "5.0"}
+    installed_packages = {"packaging": "24", "numpy": "2.2.6", "pyDOE": "", "PyYAML": "5.0"}
 else:
     pip_freeze_list = subprocess.check_output([sys.executable, '-m', 'pip', 'list', '--format=freeze'])
     pip_freeze_list = [line.decode().split('==') for line in pip_freeze_list.split()]

--- a/tests/mocks/sampler_black-box.py
+++ b/tests/mocks/sampler_black-box.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+#===================================================
+#
+#    Copyright (c) 2023-2025
+#      SMASH Hybrid Team
+#
+#    GNU General Public License (GPLv3 or later)
+#
+#===================================================
+
 # README:
 # If the environment variable BLACK_BOX_TYPE_SAMPLER is set to "FIST", the script is called like:
 #

--- a/tests/mocks/smash_IC_black-box.py
+++ b/tests/mocks/smash_IC_black-box.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+#===================================================
+#
+#    Copyright (c) 2023-2025
+#      SMASH Hybrid Team
+#
+#    GNU General Public License (GPLv3 or later)
+#
+#===================================================
+
 import argparse
 import os
 import shutil

--- a/tests/mocks/smash_afterburner_black-box.py
+++ b/tests/mocks/smash_afterburner_black-box.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+#===================================================
+#
+#    Copyright (c) 2023-2025
+#      SMASH Hybrid Team
+#
+#    GNU General Public License (GPLv3 or later)
+#
+#===================================================
+
 import argparse
 import os
 import sys

--- a/tests/mocks/vhlle_black-box.py
+++ b/tests/mocks/vhlle_black-box.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+#===================================================
+#
+#    Copyright (c) 2023-2025
+#      SMASH Hybrid Team
+#
+#    GNU General Public License (GPLv3 or later)
+#
+#===================================================
+
 import argparse
 import os
 import sys


### PR DESCRIPTION
This closes #88 and adds the missing copyright statements mentioned in #83. Since I added the "old" copyright statement, this PR should be merged before #85.