### PR TITLE
Add Python formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build*/
 binaries
 python_scripts/*.pyc
 site/
+*venv*/
 
 # OS specific auxiliary files
 .vscode

--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -96,7 +96,7 @@ function Act_And_Exit_If_User_Ran_Auxiliary_Modes()
             ;;&
         format)
             Format_Codebase
-            Run_Formatting_Unit_Test
+            Run_Formatting_Unit_Tests
             ;;&
         version)
             Print_Software_Version

--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -96,7 +96,6 @@ function Act_And_Exit_If_User_Ran_Auxiliary_Modes()
             ;;&
         format)
             Format_Codebase
-            Run_Formatting_Unit_Tests
             ;;&
         version)
             Print_Software_Version

--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -40,7 +40,7 @@ function Enable_Desired_Shell_Behavior()
 {
     # Set stricter bash mode (see CONTRIBUTING for more information)
     set -o pipefail -o nounset -o errexit
-    shopt -s extglob inherit_errexit
+    shopt -s extglob globstar inherit_errexit
 }
 
 function Setup_Initial_And_Final_Output_Space()

--- a/bash/formatter.bash
+++ b/bash/formatter.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -19,14 +19,24 @@ function Format_Codebase()
     fi
 }
 
-function Run_Formatting_Unit_Test()
+function Run_Formatting_Unit_Tests()
 {
     Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
     source "${HYBRID_top_level_path}/tests/unit_tests_formatting.bash" || exit ${HYBRID_fatal_builtin}
     # The following variable definition is just a patch to be able to reuse the test code from here
     HYBRIDT_repository_top_level_path="${HYBRID_top_level_path}"
-    if Unit_Test__codebase-formatting; then
-        Print_Info 'The codebase was correctly formatted and the formatting test passes.'
+    local bash_format_correct='FALSE'
+    local python_format_correct='FALSE'
+    if Unit_Test__codebase-formatting-Bash; then
+        bash_format_correct='TRUE'
+    else
+        printf '\n'
+    fi
+    if Unit_Test__codebase-formatting-Python; then
+        python_format_correct='TRUE'
+    fi
+    if [[ "${bash_format_correct}" = 'TRUE' ]] && [[ "${python_format_correct}" = 'TRUE' ]]; then
+        Print_Info 'The codebase was correctly formatted and the formatting tests pass.'
     fi
 }
 

--- a/bash/formatter.bash
+++ b/bash/formatter.bash
@@ -11,53 +11,61 @@ function Format_Codebase()
 {
     local bash_formatter_found='TRUE'
     local python_formatter_found='TRUE'
+    local bash_format_succeeded='FALSE'
+    local python_format_succeeded='FALSE'
+    Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
     if ! hash shfmt &> /dev/null; then
         Print_Error \
-            'Command ' --emph 'shfmt' ' not available.' \
-            'Please install it (https://github.com/mvdan/sh#shfmt).\n'
+            'Command ' --emph 'shfmt' ' not available. Please install it (https://github.com/mvdan/sh#shfmt)' \
+            'to format the ' --emph 'Bash' ' files of the codebase.\n'
         bash_formatter_found='FALSE'
+    else
+        shfmt -w -ln bash -i 4 -bn -ci -sr -fn "${HYBRID_top_level_path}" &> /dev/null \
+            || Print_Internal_And_Exit 'Bash formatter ' --emph 'shfmt' ' unexpectedly failed.'
     fi
     if ! hash autopep8 &> /dev/null; then
         Print_Error \
-            'Command ' --emph 'autopep8' ' not available.' \
-            'Please install it (https://pypi.org/project/autopep8).\n'
+            'Command ' --emph 'autopep8' ' not available. Please install it (https://pypi.org/project/autopep8)' \
+            'to format the ' --emph 'Python' ' files of the codebase.\n'
         python_formatter_found='FALSE'
-    fi
-    if [[ "${bash_formatter_found}" = 'TRUE' ]] && [[ "${python_formatter_found}" = 'TRUE' ]]; then
-        Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
-        shfmt -w -ln bash -i 4 -bn -ci -sr -fn "${HYBRID_top_level_path}"
-        local list_of_python_files=(
-            "${HYBRID_python_folder}/"*.py
-            "${HYBRID_top_level_path}/tests/"**/*.py
-        )
-        for file in ${list_of_python_files[@]}; do
-            # Ignoring rule E26, i.e. not enforcing a single whitespace after the # of inline comments
-            autopep8 --ignore "E26" -i "${file}"
-        done
     else
-        Print_Fatal_And_Exit 'Unable to format the codebase. ' \
-            'Please install the missing requirements and run the formatting again.'
+        # Ignoring rule E265, i.e. not enforcing a single whitespace after the # of block comments
+        autopep8 --ignore "E265" --max-line-length 119 -i "${HYBRID_top_level_path}/"{python,tests}/**/*.py \
+            &> /dev/null || Print_Internal_And_Exit 'Python formatter ' --emph 'autopep8' ' unexpectedly failed.'
+        python_format_succeeded='TRUE'
+    fi
+    if [[ ${bash_formatter_found} = 'FALSE' ]] && [[ ${python_formatter_found} = 'FALSE' ]]; then
+        Print_Fatal_And_Exit 'Unable to format the codebase. Please install the missing requirements ' \
+            'and run the formatting again.'
+    elif [[ ${bash_formatter_found} = 'TRUE' ]]; then
+        # NOTE: The Bash unit test is run since it does an additonal line length check on top of what the formatter
+        #       does. The Python unit test will not fail after formatting, so it is redundant to run it.
+        if __static__Run_Bash_Formatting_Unit_Test; then
+            bash_format_succeeded='TRUE'
+        else
+            Print_Info -l -- ''
+        fi
+    fi
+    if [[ ${bash_format_succeeded} = 'TRUE' ]] && [[ ${python_format_succeeded} = 'TRUE' ]]; then
+        Print_Info 'The codebase was correctly formatted and the ' --emph 'Bash' ' formatting test passes.'
+    elif [[ ${bash_format_succeeded} = 'FALSE' ]] && [[ ${python_format_succeeded} = 'TRUE' ]]; then
+        Print_Info 'The ' --emph 'Python' ' files of the codebase have been properly formatted.'
+    elif [[ ${bash_format_succeeded} = 'TRUE' ]] && [[ ${python_format_succeeded} = 'FALSE' ]]; then
+        Print_Info 'The ' --emph 'Bash' ' files of the codebase were correctly formatted and the ' --emph 'Bash' \
+            ' formatting test passes.'
+    else
+        Print_Internal_And_Exit 'The codebase was not correctly formatted.'
     fi
 }
 
-function Run_Formatting_Unit_Tests()
+function __static__Run_Bash_Formatting_Unit_Test()
 {
     Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
     source "${HYBRID_top_level_path}/tests/unit_tests_formatting.bash" || exit ${HYBRID_fatal_builtin}
     # The following variable definition is just a patch to be able to reuse the test code from here
     HYBRIDT_repository_top_level_path="${HYBRID_top_level_path}"
-    local bash_format_correct='FALSE'
-    local python_format_correct='FALSE'
-    if Unit_Test__codebase-formatting-Bash; then
-        bash_format_correct='TRUE'
-    else
-        printf '\n'
-    fi
-    if Unit_Test__codebase-formatting-Python; then
-        python_format_correct='TRUE'
-    fi
-    if [[ "${bash_format_correct}" = 'TRUE' ]] && [[ "${python_format_correct}" = 'TRUE' ]]; then
-        Print_Info 'The codebase was correctly formatted and the formatting tests pass.'
+    if ! Unit_Test__codebase-formatting-Bash; then
+        return 1
     fi
 }
 

--- a/bash/formatter.bash
+++ b/bash/formatter.bash
@@ -9,13 +9,34 @@
 
 function Format_Codebase()
 {
+    local bash_formatter_found='TRUE'
+    local python_formatter_found='TRUE'
     if ! hash shfmt &> /dev/null; then
-        Print_Fatal_And_Exit \
-            'Command ' --emph 'shfmt' ' not available, unable to format codebase.' \
-            'Please, install it (https://github.com/mvdan/sh#shfmt) and run the formatting again.'
-    else
+        Print_Error \
+            'Command ' --emph 'shfmt' ' not available.' \
+            'Please install it (https://github.com/mvdan/sh#shfmt).\n'
+        bash_formatter_found='FALSE'
+    fi
+    if ! hash autopep8 &> /dev/null; then
+        Print_Error \
+            'Command ' --emph 'autopep8' ' not available.' \
+            'Please install it (https://pypi.org/project/autopep8).\n'
+        python_formatter_found='FALSE'
+    fi
+    if [[ "${bash_formatter_found}" = 'TRUE' ]] && [[ "${python_formatter_found}" = 'TRUE' ]]; then
         Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
         shfmt -w -ln bash -i 4 -bn -ci -sr -fn "${HYBRID_top_level_path}"
+        local list_of_python_files=(
+            "${HYBRID_python_folder}/"*.py
+            "${HYBRID_top_level_path}/tests/"**/*.py
+        )
+        for file in ${list_of_python_files[@]}; do
+            # Ignoring rule E26, i.e. not enforcing a single whitespace after the # of inline comments
+            autopep8 --ignore "E26" -i "${file}"
+        done
+    else
+        Print_Fatal_And_Exit 'Unable to format the codebase. ' \
+            'Please install the missing requirements and run the formatting again.'
     fi
 }
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -73,7 +73,7 @@ Please, refer to their README file for more information.
 ## Used Bash behavior
 
 After long consideration, it has been decided to use some stricter Bash mode.
-In particular, the harmless `pipefail`, `nounset` and `extglob` options are enabled, together with the more controversial `errexit` one (and its sibling `inherit_errexit`).
+In particular, the harmless `pipefail`, `nounset`, `extglob`, and `globstar` options are enabled, together with the more controversial `errexit` one (and its sibling `inherit_errexit`).
 We are aware that the `errexit` option leads to many corner cases and that there are controversial opinions around.
 The advantage is its useful semantics and, more importantly, it can protect from dangerous situations (`cd NotExistingFolder; rm -r *`).
 But beware of possible gotchas.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -87,14 +87,14 @@ Finally, a short remark about `extglob` option. To motivate why we decided to en
 > An unpleasant workaround could be to use a _subshell command_ list as the function body.
 
 
-## Bash notation in the codebase
+## Conventions used and formatting the codebase
 
 The general advice is pretty trivial: **Be consistent with what you find**.
 
-The codebase is formatted using [`shfmt`](https://github.com/mvdan/sh#shfmt).
+The Bash part of the codebase is formatted using [`shfmt`](https://github.com/mvdan/sh#shfmt), while [`autopep8`](https://pypi.org/project/autopep8/) is used for the Python files.
 Any developer should be aware that, because of the nature of the Bash scripting language, it is probably impossible to have a perfect formatter, which ensure rules in all details (as e.g. `clang-format` does for C++).
 Therefore, it is crucial for the developer to stay consistent with the existing style and, more importantly, to take some minutes to read the following lists.
-In particular, be aware the the formatter will not enforce the rules explained below.
+In particular, be aware that the Bash formatter will not enforce the rules explained below.
 
 !!! tip "The main Hybrid-handler script can format the codebase!"
     Before opening a PR, make sure all tests pass.
@@ -103,7 +103,7 @@ In particular, be aware the the formatter will not enforce the rules explained b
     Use it by running `./Hybrid-handler format`.
     This is meant for developers only and therefore does not appear in the helper description.
 
-!!! info "Some aspects about the codebase"
+!!! info "Some aspects about the Bash conventions in the codebase"
     * Lines of code are split around 100 characters and should never be longer than 120.
       This is a hard limit and tests will fail if longer lines exist.
     * Bash functions use **both** the `function` keyword **and** parenthesis (with the enclosing braces on separate lines).
@@ -130,3 +130,8 @@ In particular, be aware the the formatter will not enforce the rules explained b
 
     * Indentation is done _exclusively with spaces_ and **no** <kbd>Tab</kbd> should be used.
     * Loops and conditional clauses are started on a single line, i.e. the `do` and `then` keywords are **NOT** put on a separate line.
+
+!!! info "Good to know about formatting Python files"
+    * `autopep8` is set up to intentionally ignore rule `E26`, i.e. not enforcing a single whitespace after the `#` of inline comments as recommended by the [PEP 8 – Style Guide for Python Code](https://peps.python.org/pep-0008/#inline-comments).
+      This is done to have unified copyright statements for Bash and Python files.
+      Apart from the copyright statements, developers are encouraged to use a space after the `#` of comments.

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -132,6 +132,6 @@ In particular, be aware that the Bash formatter will not enforce the rules expla
     * Loops and conditional clauses are started on a single line, i.e. the `do` and `then` keywords are **NOT** put on a separate line.
 
 !!! info "Good to know about formatting Python files"
-    * `autopep8` is set up to intentionally ignore rule `E26`, i.e. not enforcing a single whitespace after the `#` of inline comments as recommended by the [PEP 8 – Style Guide for Python Code](https://peps.python.org/pep-0008/#inline-comments).
+    * `autopep8` is set up to intentionally ignore rule `E265`, i.e. not enforcing a single whitespace after the `#` of block comments as recommended by the [PEP 8 – Style Guide for Python Code](https://peps.python.org/pep-0008/#inline-comments).
       This is done to have unified copyright statements for Bash and Python files.
       Apart from the copyright statements, developers are encouraged to use a space after the `#` of comments.

--- a/python/add_corona.py
+++ b/python/add_corona.py
@@ -20,15 +20,16 @@ import subprocess
     Hydro stage to the sampled particle list.
 '''
 
+
 def find_out_event_number(filepath):
     '''
         Look into the last line of the file and find the number of events
     '''
     if not os.path.isfile(filepath):
-        print(filepath+" does not exist!", file=sys.stderr)
+        print(filepath + " does not exist!", file=sys.stderr)
         sys.exit(2)
     tail = subprocess.run(['tail', '-n', '1', filepath],
-                          stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     last_line = tail.stdout.decode().strip().split()
     n_events = 0
     error = False
@@ -41,9 +42,10 @@ def find_out_event_number(filepath):
         error = True
     if error:
         print("The number of events cannot be found for " + filepath,
-                file=sys.stderr)
+              file=sys.stderr)
         sys.exit(3)
-    return n_events+1
+    return n_events + 1
+
 
 def extract_particles(filename):
     '''
@@ -63,8 +65,9 @@ def extract_particles(filename):
             # particle line
             else:
                 particle = np.array([int(n_event), *line[:12]])
-                particles = np.append(particles,[particle], axis=0)
-    return(particles)
+                particles = np.append(particles, [particle], axis=0)
+    return (particles)
+
 
 def gather_corona_particles(corona_lists):
     '''
@@ -87,6 +90,7 @@ def gather_corona_particles(corona_lists):
         sys.exit(4)
     return corona_particles
 
+
 def copy_header(input_file, output_file):
     header = ""
     with open(input_file, "r") as open_input:
@@ -98,6 +102,7 @@ def copy_header(input_file, output_file):
     with open(output_file, 'w') as f:
         f.write(header)
 
+
 def read_sampled_and_write_full_particle_list(args, corona_particles, n_events_ic):
     '''
         Corona particles are distributed among sampled events
@@ -108,7 +113,7 @@ def read_sampled_and_write_full_particle_list(args, corona_particles, n_events_i
         print("Sampled particles file not found!", file=sys.stderr)
         sys.exit(2)
 
-    copy_header(sampled_file,output_file)
+    copy_header(sampled_file, output_file)
 
     sampled_particles = np.empty(shape=[0, 12])
     event_s = 0
@@ -120,14 +125,14 @@ def read_sampled_and_write_full_particle_list(args, corona_particles, n_events_i
             # event end line
             if "end" in line:
                 corona_filter = corona_particles[corona_particles[:, 0] == str(event_c)]
-                particle_number = len(corona_filter)+len(sampled_particles)
+                particle_number = len(corona_filter) + len(sampled_particles)
                 with open(output_file, 'a') as f:
-                    f.write("# event {} out {}\n".format(event_s,particle_number))
+                    f.write("# event {} out {}\n".format(event_s, particle_number))
                     np.savetxt(f, sampled_particles, delimiter=' ', fmt='%s')   # write sampled
-                    np.savetxt(f, corona_filter[:,1:], delimiter=' ', fmt='%s') # write corona
+                    np.savetxt(f, corona_filter[:, 1:], delimiter=' ', fmt='%s')  # write corona
                     f.write("# event {} end\n".format(event_s))
                 # reset relevant variables
-                if event_c < (n_events_ic-1):
+                if event_c < (n_events_ic - 1):
                     event_c += 1
                 else:
                     event_c = 0
@@ -139,25 +144,26 @@ def read_sampled_and_write_full_particle_list(args, corona_particles, n_events_i
             # particle line
             else:
                 particle = np.array(line[:12])
-                sampled_particles = np.append(sampled_particles,[particle], axis=0)
+                sampled_particles = np.append(sampled_particles, [particle], axis=0)
+
 
 if __name__ == '__main__':
     # pass arguments from the command line to the script
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s","--sampled_particle_list", required = True,
+    parser.add_argument("-s", "--sampled_particle_list", required=True,
                         help="File containing the sampled particle lists.")
-    parser.add_argument("-c","--corona_particle_lists", nargs='+', required = True,
+    parser.add_argument("-c", "--corona_particle_lists", nargs='+', required=True,
                         help="Particle list from the initial conditions SMASH run.")
-    parser.add_argument("-o","--output_file", required = True,
-                        help="Resulting particle list containing " \
+    parser.add_argument("-o", "--output_file", required=True,
+                        help="Resulting particle list containing "
                         "sampled and spectator particles.")
     parser.add_argument("-f", "--force", action='store_true',
-                        help = "Ignore pre-existing output file.")
+                        help="Ignore pre-existing output file.")
     args = parser.parse_args()
 
     output = args.output_file
     if os.path.isfile(output):
-        print(output+" already exists!", file=sys.stderr)
+        print(output + " already exists!", file=sys.stderr)
         if not args.force:
             sys.exit(5)
 

--- a/python/add_spectators.py
+++ b/python/add_spectators.py
@@ -138,16 +138,15 @@ def write_full_particle_list(spectator_list):
 if __name__ == '__main__':
     # pass arguments from the command line to the script
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sampled_particle_list", required = True,
+    parser.add_argument("--sampled_particle_list", required=True,
                         help="File containing the sampled particle lists.")
-    parser.add_argument("--initial_particle_list", required = True,
+    parser.add_argument("--initial_particle_list", required=True,
                         help="Particle list from the initial conditions SMASH run.")
-    parser.add_argument("--output_file", required = True,
+    parser.add_argument("--output_file", required=True,
                         help="Resulting particle list containing sampled and spectator particles.")
-    parser.add_argument("--smash_config", required = True,
+    parser.add_argument("--smash_config", required=True,
                         help="SMASH config file employed for the initial conditions.")
     args = parser.parse_args()
-
 
     spectators = extract_spectators()
     write_full_particle_list(spectators)

--- a/python/latin_hypercube_sampling.py
+++ b/python/latin_hypercube_sampling.py
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024-2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -15,6 +15,8 @@ import ast
 from pyDOE import lhs
 
 #scale the hypercube to the specified ranges
+
+
 def generate_points_from_ranges(ranges, unit_points):
     points = []
     for i in range(len(unit_points)):
@@ -27,30 +29,31 @@ def generate_points_from_ranges(ranges, unit_points):
         points.append(sample)
     return np.array(points)
 
+
 if __name__ == '__main__':
     # pass arguments from the command line to the script
     parser = argparse.ArgumentParser()
-    parser.add_argument("--parameter_names", required = True, nargs='+',
+    parser.add_argument("--parameter_names", required=True, nargs='+',
                         help="Names of the parameters to be sampled.")
-    parser.add_argument("--parameter_ranges", required = True, nargs='+',
+    parser.add_argument("--parameter_ranges", required=True, nargs='+',
                         help="Ranges of the parameters to be sampled.")
-    parser.add_argument("--num_samples", required = True,
+    parser.add_argument("--num_samples", required=True,
                         help="Number of samples to be drawn.")
     args = parser.parse_args()
     parameter_names = args.parameter_names
     parameter_ranges = args.parameter_ranges
     if len(parameter_names) != len(parameter_ranges) or int(args.num_samples) < 2:
         raise ValueError("The number of parameter names and parameter ranges must match and"
-                          +"number of samples must be greater 1")
+                         + "number of samples must be greater 1")
     parameter_ranges = np.array([ast.literal_eval(i) for i in parameter_ranges])
     unit = lhs(parameter_ranges.shape[0], samples=int(args.num_samples), criterion='centermaximin')
-    result=generate_points_from_ranges(parameter_ranges, unit).transpose()
-    return_string=""
+    result = generate_points_from_ranges(parameter_ranges, unit).transpose()
+    return_string = ""
     for i in range(len(parameter_names)):
         return_string += parameter_names[i] + "=["
         for j in range(result.shape[1]):
             return_string += str(result[i][j])
-            if j != result.shape[1]-1:
+            if j != result.shape[1] - 1:
                 return_string += ","
             else:
                 return_string += "]\n"

--- a/python/test_requirement.py
+++ b/python/test_requirement.py
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024-2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)

--- a/tests/mocks/sampler_black-box.py
+++ b/tests/mocks/sampler_black-box.py
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023,2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -54,10 +54,12 @@ from packaging.version import Version
 
 sampler_version = os.environ.get("MOCK_HADRON_SAMPLER_VERSION", "3.1.1")
 
+
 def print_version_and_exit_if_requested():
     if sys.argv[1] == '--version':
         print(sampler_version)
         sys.exit(0)
+
 
 def check_input_arguments(mode):
     """
@@ -106,6 +108,7 @@ def check_input_arguments(mode):
                 print("Invalid number of arguments!\n" + calling_instruction)
                 sys.exit(1)
 
+
 def check_if_file_exists(path, mode, ftype=None):
     """
     Checks if the file (path) exists. In FIST mode, prints specialized error messages
@@ -114,7 +117,7 @@ def check_if_file_exists(path, mode, ftype=None):
     if mode == 'FIST':
         if not os.path.isfile(path):
             if ftype == "hypersurface":
-                print(f"Hypersurface file  {path} not found! \n Empty hypersurface! Aborting...")
+                print(f"Hypersurface file {path} not found! \n Empty hypersurface! Aborting...")
             elif ftype == "decays":
                 print("**WARNING** rho0 (113): Particle marked unstable but no decay channels found!")
                 sys.exit(1)
@@ -130,19 +133,22 @@ def check_if_file_exists(path, mode, ftype=None):
             print(f"File not found at given path: {path}")
             sys.exit(1)
 
+
 def check_if_directory_exists(path):
     if not os.path.isdir(path):
         err_msg = path + ' is not a valid directory or does not exist!'
         print(err_msg)
         sys.exit(1)
 
+
 def get_first_two_fields_in_line(line_in_config):
     #deleting the last character to omit the newline character '\n'
     line_in_config = line_in_config[:-1].split(' ')
     splitted_line_in_config = list(filter(None, line_in_config))
-    splitted_line_in_config[0]=str(splitted_line_in_config[0])
-    splitted_line_in_config[1]=str(splitted_line_in_config[1])
+    splitted_line_in_config[0] = str(splitted_line_in_config[0])
+    splitted_line_in_config[1] = str(splitted_line_in_config[1])
     return splitted_line_in_config
+
 
 def get_value_as_string_from_config_by_keyword(path_to_config, keyword, custom_error=None):
     """
@@ -160,14 +166,16 @@ def get_value_as_string_from_config_by_keyword(path_to_config, keyword, custom_e
         print(f"Keyword '{keyword}' not found in config file!")
     sys.exit(1)
 
+
 def make_fake_run(mode):
     if mode == 'FIST':
         print("\nRunning FIST-Sampler:\n")
     else:
         print(f"\nRunning SMASH-Sampler v{sampler_version}:\n")
     for i in range(11):
-        print('Fake computational progress: ', int(10*i), '%')
+        print('Fake computational progress: ', int(10 * i), '%')
         time.sleep(0.1)
+
 
 def create_output_file(mode, outpath):
     """
@@ -223,6 +231,7 @@ def create_output_file(mode, outpath):
             f_out.write(f'# event {counter_event} end 0 impact   0.000 scattering_projectile_target yes\n')
 
 ####################   End Definitions   ####################
+
 
 def run_black_box():
     """
@@ -312,6 +321,7 @@ def run_black_box():
     # Otherwise proceed with a normal run
     make_fake_run(mode)
     create_output_file(mode, outpath)
+
 
 if __name__ == "__main__":
     run_black_box()

--- a/tests/mocks/smash_IC_black-box.py
+++ b/tests/mocks/smash_IC_black-box.py
@@ -18,10 +18,12 @@ import time
 
 ic_version = os.environ.get("MOCK_IC_VERSION", "3.2")
 
+
 def print_version_and_exit_if_requested():
     if args.version:
         print(f"SMASH-{ic_version}")
         sys.exit(0)
+
 
 def check_config(valid_config):
     if args.i is None:
@@ -34,9 +36,11 @@ def check_config(valid_config):
         sys.exit(1)
     return
 
+
 def print_terminal_start():
     print("\nRunning SMASH IC:\n")
     return
+
 
 def create_folders_structure():
     # if no path is given, create folder structure
@@ -60,25 +64,28 @@ def create_folders_structure():
         args.o += "/"
     return
 
+
 def validate_output_folder():
     f_config = args.o + "config.yaml"
     if os.path.exists(f_config):
-        print(fatal_error + "Output directory would get overwritten. Select a different output directory, clean up, or tell SMASH to ignore existing files.")
+        print(fatal_error + "Output directory would get overwritten." +
+              "Select a different output directory, clean up, or tell SMASH to ignore existing files.")
         sys.exit(1)
     else:
         # create config file copying input one to output folder
         shutil.copy(args.i, f_config)
     return
 
+
 def run_smash(finalize):
     # create smash.lock file
-    f = open(args.o+file_name_is_running, "w")
+    f = open(args.o + file_name_is_running, "w")
     f.close()
     # open unfinished particle files
-    particles_out_oscar = open(SMASH_output_file_with_participants_and_spectators+name_unfinished, "w")
-    particles_out_dat = open(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished, "w")
+    particles_out_oscar = open(SMASH_output_file_with_participants_and_spectators + name_unfinished, "w")
+    particles_out_dat = open(SMASH_special_output_file_for_vHLLE_with_participants_only + name_unfinished, "w")
     # run the black box
-    for ts in range(1,11):
+    for ts in range(1, 11):
         print("running t = {} fm".format(ts))
         time.sleep(0.1)
     particles_out_oscar.close()
@@ -87,27 +94,31 @@ def run_smash(finalize):
     if finalize:
         finish()
     else:
-        print(fatal_error+"crash")
+        print(fatal_error + "crash")
         sys.exit(1)
     return
 
+
 def finish():
     # rename output by removing the .unfinished file ending
-    if os.path.exists(SMASH_output_file_with_participants_and_spectators+name_unfinished):
-        os.rename(SMASH_output_file_with_participants_and_spectators+name_unfinished, SMASH_output_file_with_participants_and_spectators)
+    if os.path.exists(SMASH_output_file_with_participants_and_spectators + name_unfinished):
+        os.rename(SMASH_output_file_with_participants_and_spectators +
+                  name_unfinished, SMASH_output_file_with_participants_and_spectators)
     else:
         print("somehow the output (.oscar) file was not properly written")
         sys.exit(1)
 
-    if os.path.exists(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished):
-        os.rename(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished, SMASH_special_output_file_for_vHLLE_with_participants_only)
+    if os.path.exists(SMASH_special_output_file_for_vHLLE_with_participants_only + name_unfinished):
+        os.rename(SMASH_special_output_file_for_vHLLE_with_participants_only +
+                  name_unfinished, SMASH_special_output_file_for_vHLLE_with_participants_only)
     else:
         print("somehow the output file (.dat) was not properly written")
         sys.exit(1)
 
     # remove smash.lock file
-    os.remove(args.o+file_name_is_running)
+    os.remove(args.o + file_name_is_running)
     return
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
@@ -144,8 +155,8 @@ if __name__ == '__main__':
     create_folders_structure()
     validate_output_folder()
 
-    SMASH_output_file_with_participants_and_spectators = args.o+name_particles_file+name_oscar
-    SMASH_special_output_file_for_vHLLE_with_participants_only = args.o+name_particles_file+name_dat
+    SMASH_output_file_with_participants_and_spectators = args.o + name_particles_file + name_oscar
+    SMASH_special_output_file_for_vHLLE_with_participants_only = args.o + name_particles_file + name_dat
 
     # smash is now ready to run
     print_terminal_start()

--- a/tests/mocks/smash_afterburner_black-box.py
+++ b/tests/mocks/smash_afterburner_black-box.py
@@ -16,20 +16,23 @@ import textwrap
 import time
 import yaml
 
+
 def check_config(valid_config):
     if args.i is None:
         args.i = "./config.yaml"
     if not os.path.exists(args.i):
-        print(fatal_error+"The configuration file was expected at './config.yaml', but the file does not exist.")
+        print(fatal_error + "The configuration file was expected at './config.yaml', but the file does not exist.")
         sys.exit(1)
     if not valid_config:
-        print(fatal_error+"Validation of SMASH input failed.")
+        print(fatal_error + "Validation of SMASH input failed.")
         sys.exit(1)
     return
+
 
 def print_terminal_start():
     print("\nRunning SMASH Afterburner:\n")
     return
+
 
 def create_folders_structure():
     # if no path is given, create folder structure
@@ -53,10 +56,12 @@ def create_folders_structure():
         args.o += "/"
     return
 
+
 def ensure_no_output_is_overwritten():
     f_config = args.o + "config.yaml"
     if os.path.exists(f_config):
-        print(fatal_error + "Output directory would get overwritten. Select a different output directory, clean up, or tell SMASH to ignore existing files.")
+        print(fatal_error + "Output directory would get overwritten." +
+              "Select a different output directory, clean up, or tell SMASH to ignore existing files.")
         sys.exit(1)
     else:
         # create config file
@@ -64,20 +69,21 @@ def ensure_no_output_is_overwritten():
         f.close()
     return
 
-def run_smash(finalize,SMASH_input_file_with_participants_and_spectators,sampler_dir):
+
+def run_smash(finalize, SMASH_input_file_with_participants_and_spectators, sampler_dir):
     # create smash.lock file
-    f = open(args.o+file_name_is_running, "w")
+    f = open(args.o + file_name_is_running, "w")
     try:
-        f_in = open(sampler_dir+SMASH_input_file_with_participants_and_spectators, "r")
+        f_in = open(sampler_dir + SMASH_input_file_with_participants_and_spectators, "r")
         f_in.close()
         print("File read")
     except OSError:
-        print(fatal_error+"Sampled particle list could not be opened")
+        print(fatal_error + "Sampled particle list could not be opened")
         sys.exit(1)
     f.close()
     # open unfinished particle files
-    particles_out_oscar = open(SMASH_output_file_with_participants_and_spectators+name_unfinished, "w")
-    particles_out_bin = open(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished, "w")
+    particles_out_oscar = open(SMASH_output_file_with_participants_and_spectators + name_unfinished, "w")
+    particles_out_bin = open(SMASH_special_output_file_for_vHLLE_with_participants_only + name_unfinished, "w")
     # run the black box
     for ts in range(2):
         print("running t = {} fm".format(ts))
@@ -88,42 +94,46 @@ def run_smash(finalize,SMASH_input_file_with_participants_and_spectators,sampler
     if finalize:
         finish()
     else:
-        print(fatal_error+"crash")
+        print(fatal_error + "crash")
         sys.exit(1)
     return
 
+
 def finish():
     # rename output by removing the .unfinished file ending
-    if os.path.exists(SMASH_output_file_with_participants_and_spectators+name_unfinished):
-        os.rename(SMASH_output_file_with_participants_and_spectators+name_unfinished, SMASH_output_file_with_participants_and_spectators)
+    if os.path.exists(SMASH_output_file_with_participants_and_spectators + name_unfinished):
+        os.rename(SMASH_output_file_with_participants_and_spectators +
+                  name_unfinished, SMASH_output_file_with_participants_and_spectators)
     else:
         print("somehow the output (.oscar) file was not properly written")
         sys.exit(1)
 
-    if os.path.exists(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished):
-        os.rename(SMASH_special_output_file_for_vHLLE_with_participants_only+name_unfinished, SMASH_special_output_file_for_vHLLE_with_participants_only)
+    if os.path.exists(SMASH_special_output_file_for_vHLLE_with_participants_only + name_unfinished):
+        os.rename(SMASH_special_output_file_for_vHLLE_with_participants_only +
+                  name_unfinished, SMASH_special_output_file_for_vHLLE_with_participants_only)
     else:
         print("somehow the output file (.bin) was not properly written")
         sys.exit(1)
 
     # remove smash.lock file
-    os.remove(args.o+file_name_is_running)
+    os.remove(args.o + file_name_is_running)
     return
+
 
 def parse_command_line_config_options():
     with open(args.i, 'r') as file:
         data_config = yaml.safe_load(file)
 
-    sampler_dir=""
+    sampler_dir = ""
 
     try:
-        sampler_dir=data_config['Modi']['List']['File_Directory']
+        sampler_dir = data_config['Modi']['List']['File_Directory']
     except KeyError:
         print("File directory could not be parsed")
         sys.exit(1)
 
     try:
-        file=data_config['Modi']['List']['Filename']
+        file = data_config['Modi']['List']['Filename']
     except KeyError:
         print("Filename could not be parsed")
         sys.exit(1)
@@ -164,14 +174,14 @@ if __name__ == '__main__':
 
     # initialize the system
     check_config(config_is_valid)
-    sampler_dir, file =parse_command_line_config_options()
+    sampler_dir, file = parse_command_line_config_options()
     create_folders_structure()
     ensure_no_output_is_overwritten()
 
-    SMASH_input_file_with_participants_and_spectators = sampler_dir+file
-    SMASH_output_file_with_participants_and_spectators = args.o+name_particles_file+name_oscar
-    SMASH_special_output_file_for_vHLLE_with_participants_only = args.o+name_particles_file+name_bin
+    SMASH_input_file_with_participants_and_spectators = sampler_dir + file
+    SMASH_output_file_with_participants_and_spectators = args.o + name_particles_file + name_oscar
+    SMASH_special_output_file_for_vHLLE_with_participants_only = args.o + name_particles_file + name_bin
 
     # smash is now ready to run
     print_terminal_start()
-    run_smash(smash_finishes,SMASH_input_file_with_participants_and_spectators,sampler_dir)
+    run_smash(smash_finishes, SMASH_input_file_with_participants_and_spectators, sampler_dir)

--- a/tests/mocks/vhlle_black-box.py
+++ b/tests/mocks/vhlle_black-box.py
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023,2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -17,9 +17,11 @@ import time
 import datetime
 import textwrap
 
+
 def print_terminal_start():
     print("\nRunning Hydro:\n")
     return
+
 
 def read_parameters(configFile):
     # list of possible parameters
@@ -73,6 +75,7 @@ def read_parameters(configFile):
                     parameters[key][1] = line[1]
     return parameters
 
+
 def print_parameters():
     print("vhlle: reading parameters from ", args.params)
     print("vhlle: command line parameters are:")
@@ -87,6 +90,7 @@ def print_parameters():
     print("======= end parameters =======")
     return
 
+
 def create_folder(outputDirSpecified):
     # create path if needed
     if outputDirSpecified:
@@ -100,6 +104,7 @@ def create_folder(outputDirSpecified):
         print("mkdir: missing operand")
     return
 
+
 def check_command_line():
     # check if there are command# check if there is a config file
     if len(sys.argv) < 2:
@@ -112,6 +117,7 @@ def check_command_line():
             sys.exit(1)
     return
 
+
 def check_eos():
     # no real check at this point we assume the eos folder exists
     # where hlle_visc executable is
@@ -122,11 +128,13 @@ def check_eos():
     if eosExists:
         print("EoSaux: table eos/chiraleos.dat read, [emin,emax,nmin,nmax] = 0  146  0  6")
         print("EoSaux: table eos/chiralsmall.dat read, [emin,emax,nmin,nmax] = 0  1.46  0  0.3")
-        print("EoSSMASH: table eos/hadgas_eos_SMASH.dat read, [emin,emax,nbmin,nbmax,qmin,qmax] = 0  1  0  0.5 -0.1  0.4")
+        print(
+            "EoSSMASH: table eos/hadgas_eos_SMASH.dat read, [emin,emax,nbmin,nbmax,qmin,qmax] = 0  1  0  0.5 -0.1  0.4")
     else:
         print("I/O error with eos/chiraleos.dat")
         sys.exit(1)
     return
+
 
 def exit_without_config(outputDirSpecified):
     if args.params == "":
@@ -142,6 +150,7 @@ Init time = 6 [sec]""")
         print("{: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10}".format(*valueList))
         sys.exit(1)
     return
+
 
 def read_initial_state():
     messageExample = """particle E = 1442.11  Nbar = 367  Ncharge = 148 Ns = 0
@@ -159,6 +168,7 @@ Init time = 9 [sec]"""
         print("I/O error with", args.ISinput)
         sys.exit(1)
 
+
 def print_timestep(timestep):
     randomList = []
     for i in range(1, 10):
@@ -174,7 +184,7 @@ def run_hydro(outputDirSpecified):
     # create freezout hypersurface file
     # only if output directory is specified
     if outputDirSpecified:
-        freezeout = open(args.outputDir+"freezeout.dat", "w")
+        freezeout = open(args.outputDir + "freezeout.dat", "w")
     variableList = ["tau", "E", "Efull", "Nb", "Sfull", "EtotSurf", "elements", "susp.", "%cut"]
     # run the black box
     print("{: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10} {: >10}".format(*variableList))

--- a/tests/python_requirements.txt
+++ b/tests/python_requirements.txt
@@ -1,5 +1,6 @@
 # Even if some requirements here are the same as for the handler, we repeat them
 # as in unit tests the handler code checking requirements does not necessarily run.
 
+autopep8~=2.3.2
 pyDOE~=0.3.8
 PyYAML~=6.0.1

--- a/tests/tests_runner
+++ b/tests/tests_runner
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023
+#    Copyright (c) 2023,2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -55,7 +55,7 @@ function Setup_Initial_And_Final_Output_Space()
 function Enable_Global_Needed_Shell_Options()
 {
     # See developer guide for explanation about why globally
-    shopt -s extglob
+    shopt -s extglob globstar
     set -o pipefail -o nounset
     # NOTE: The behavior about 'errexit' mode here is not the same as in the handler, i.e. we do
     #       not enable such a mode globally. This is because we want to easily have access to exit

--- a/tests/unit_tests_formatting.bash
+++ b/tests/unit_tests_formatting.bash
@@ -1,13 +1,13 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2025
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
 #
 #===================================================
 
-function Unit_Test__codebase-formatting()
+function Unit_Test__codebase-formatting-Bash()
 {
     local formatter_found='FALSE'
     if hash shfmt &> /dev/null; then
@@ -26,7 +26,6 @@ function Unit_Test__codebase-formatting()
     for file in "${list_of_source_files[@]}"; do
         if [[ $(wc -L < "${file}") -gt ${max_length} ]]; then
             files_with_too_long_lines+=("${file}")
-            continue
         fi
     done
     files_with_wrong_formatting=()
@@ -41,7 +40,7 @@ function Unit_Test__codebase-formatting()
     local report_before='FALSE'
     if [[ ${#files_with_too_long_lines[@]} -gt 0 ]]; then
         Print_Error \
-            'There are ' --emph "${#files_with_too_long_lines[@]}" ' file(s) with lines longer than ' \
+            'There are ' --emph "${#files_with_too_long_lines[@]} Bash" ' file(s) with lines longer than ' \
             --emph "${max_length}" ' characters:'
         for file in "${files_with_too_long_lines[@]}"; do
             Print_Error -l -- ' - ' \
@@ -55,7 +54,7 @@ function Unit_Test__codebase-formatting()
             printf '\n'
         fi
         Print_Error \
-            'There are ' --emph "${#files_with_wrong_formatting[@]}" ' file(s) wrongly formatted:'
+            'There are ' --emph "${#files_with_wrong_formatting[@]} Bash" ' file(s) wrongly formatted:'
         for file in "${files_with_wrong_formatting[@]}"; do
             Print_Error -l -- ' - ' \
                 --emph "$(realpath --relative-base="${HYBRIDT_repository_top_level_path}" "${file}")"
@@ -63,6 +62,45 @@ function Unit_Test__codebase-formatting()
         Print_Info '\nRun ' --emph 'Hybrid-handler format' ' to correctly format the codebase.'
     fi
     if ((${#files_with_too_long_lines[@]} + ${#files_with_wrong_formatting[@]} > 0)) \
+        || [[ ${formatter_found} = 'FALSE' ]]; then
+        return 1
+    fi
+}
+
+function Unit_Test__codebase-formatting-Python()
+{
+    local formatter_found='FALSE'
+    if hash autopep8 &> /dev/null; then
+        formatter_found='TRUE'
+    else
+        Print_Error 'Command ' --emph 'autopep8' \
+            ' not available, unable to fully check codebase formatting.'
+    fi
+    local list_of_python_files files_with_wrong_formatting file
+    list_of_python_files=(
+        "${HYBRIDT_repository_top_level_path}/"{python,tests}/**/*.py
+    )
+    files_with_wrong_formatting=()
+    if [[ ${formatter_found} = 'TRUE' ]]; then
+        for file in "${list_of_python_files[@]}"; do
+            # Ignoring rule E265, i.e. not enforcing a single whitespace after the # of block comments
+            if autopep8 --ignore "E265" --max-line-length 119 -d --exit-code "${file}" &> /dev/null; then
+                continue
+            else
+                files_with_wrong_formatting+=("${file}")
+            fi
+        done
+    fi
+    if [[ ${#files_with_wrong_formatting[@]} -gt 0 ]]; then
+        Print_Error \
+            'There are ' --emph "${#files_with_wrong_formatting[@]} Python" ' file(s) wrongly formatted:'
+        for file in "${files_with_wrong_formatting[@]}"; do
+            Print_Error -l -- ' - ' \
+                --emph "$(realpath --relative-base="${HYBRIDT_repository_top_level_path}" "${file}")"
+        done
+        Print_Info '\nRun ' --emph 'Hybrid-handler format' ' to correctly format the codebase.'
+    fi
+    if ((${#files_with_wrong_formatting[@]} > 0)) \
         || [[ ${formatter_found} = 'FALSE' ]]; then
         return 1
     fi


### PR DESCRIPTION
Resolves #83.

I added `Python` formatting to the codebase based on `autopep8` which is set up to ignore rule `E26` to have unified copyright statements for `Bash` and `Python` files. The version for the testing framework is fixed to `autopep8==2.3.2`. @AxelKrypton, should we relax this to `autopep8~=2.3.2` or is it fine this way?

I'm not entirely happy that `Print_Info '\nRun ' --emph 'Hybrid-handler format' ' to correctly format the codebase.'` will be printed twice when both `Bash` and `Python` files are not correctly formatted (this is output of the unit test functions). But I do not see an easy solution for this right now.

I also added `*venv*` to the `.gitignore` file.