### PR TITLE
Add warning to doc if not the latest version and set `alias: true`

### DIFF
--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -7,7 +7,7 @@ hide:
 # From great power comes great responsibility
 
 The Hybrid-handler has been developed trying to make the entry point of a newbie developer as low as possible.
-Although :simple-gnubash: **Bash** can be sometimes not that simple to read[^1], the integration-operation segregation principle ([IOSP](https://clean-code-developer.com/grades/grade-1-red/)) has been used most of the times at the the top-level to allow the reader to get a first understanding of what the main functions are doing, having then the possibility to deepen into lower levels if needed.
+Although :simple-gnubash: **Bash** can be sometimes not that simple to read[^1], the integration-operation segregation principle ([IOSP](https://clean-code-developer.de/en/the-straight/red-degree/)) has been used most of the times at the the top-level to allow the reader to get a first understanding of what the main functions are doing, having then the possibility to deepen into lower levels if needed.
 Said differently, reading the code top-down should be straightforward, as the most top-level function is a series of function calls only, whose names should clearly describe what is done.
 
 Therefore, this guide is not meant to document any possible implementation detail, but rather provide the reader with important information, which might be difficult to grasp by reading the codebase.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You are currently viewing documentation for an older version.
+
+<a href="{{ '../' ~ base_url }}">
+
+<strong>Click here to go to the latest.</strong>
+
+</a>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ extra:
       name: SMASH transport organization
   version:
     provider: mike
+    alias: true
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2024-2025
+#    Copyright (c) 2024-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -12,7 +12,7 @@
 # tabs in the documentation).
 
 site_name: Hybrid-handler
-copyright: Copyright &copy; 2024-2025 - Hybrid-handler Team
+copyright: Copyright &copy; 2024-2026 - Hybrid-handler Team
 
 repo_url: https://github.com/smash-transport/smash-vhlle-hybrid
 repo_name: 'Repository'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ theme:
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
+  custom_dir: docs/overrides
 
 extra:
   social:
@@ -132,6 +133,9 @@ extra:
       name: SMASH transport organization
   version:
     provider: mike
+    default:
+      - latest
+      - develop
     alias: true
 
 extra_css:


### PR DESCRIPTION
This closes #63.

This PR implements the following:
- adds a warning if the user is not on the latest version (excluding `develop`)
- sets `alias: true`, i.e. the most recent release states `latest`
- fixes a dead link.

As already mentioned in the issue, some published documentations have to be re-deployed after the merge.