### PR TITLE
Exchange forgotten old framework name with 'Hybrid-handler'

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: "1.2.0"
 message: "If you use this software, please cite it using these metadata."
 title: "smash-transport/smash-vhlle-hybrid: Hybrid-handler"
-version: "SMASH-vHLLE-hybrid-2.1.3"
+version: "Hybrid-handler-2.1.3"
 date-released: "2025-06-05"
 doi: "10.5281/zenodo.15880336"
 license: "GPL-3.0"

--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -2,7 +2,7 @@
 
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -19,7 +19,7 @@
 #                                                                            #
 #----------------------------------------------------------------------------#
 
-readonly HYBRID_codebase_version='SMASH-vHLLE-hybrid-2.1.3-unreleased'
+readonly HYBRID_codebase_version='Hybrid-handler-2.1.3-unreleased'
 
 function Main()
 {

--- a/docs/developer/release_procedure.md
+++ b/docs/developer/release_procedure.md
@@ -60,16 +60,18 @@ Closing the branch means to merge it into `main`, which will be tagged and conta
 === "Close the release branch"
     ```bash
     # Git-flow extension
-    git flow release finish 1.2.0
+    git flow release finish 1.2.0 # (1)!
 
     # Vanilla Git commands
     git switch main
     git merge --no-ff release/1.2.0
-    git tag -a 1.2.0
+    git tag -a Hybrid-handler-1.2.0
     git switch develop
     git merge --no-ff release/1.2.0
     git branch -d release/1.2.0
     ```
+
+    1. This assumes that the tag prefix `Hybrid-handler` has been set at initialisation time in the Git-flow extension!
 
 === "Publish new release"
     ```bash

--- a/tests/unit_tests_version.bash
+++ b/tests/unit_tests_version.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2024,2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -19,8 +19,8 @@ function Unit_Test__version()
     # is not used, but for example on GitHub in the self-hosted actions it will
     # be used as the repository is locally checked out effectively as a
     # black-box archive. Testing using a regex should cover all cases.
-    HYBRID_codebase_version='SMASH-vHLLE-hybrid-42.666.1'
-    HYBRID_codebase_version_regex='SMASH-vHLLE-hybrid-[0-9]+([.][0-9]+)?'
+    HYBRID_codebase_version='Hybrid-handler-42.666.1'
+    HYBRID_codebase_version_regex='Hybrid-handler-[0-9]+([.][0-9]+)?'
     local std_output
     # Unsetting PATH in the subshell so that 'git' will not be found
     std_output=$(

--- a/tests/unit_tests_version.bash
+++ b/tests/unit_tests_version.bash
@@ -20,7 +20,9 @@ function Unit_Test__version()
     # be used as the repository is locally checked out effectively as a
     # black-box archive. Testing using a regex should cover all cases.
     HYBRID_codebase_version='Hybrid-handler-42.666.1'
-    HYBRID_codebase_version_regex='Hybrid-handler-[0-9]+([.][0-9]+)?'
+    # The regex includes 'SMASH-vHLLE-hybrid' to make this test 'backward-compatible'
+    # until the next release version 2.2. Afterward, this should be removed.
+    HYBRID_codebase_version_regex='(Hybrid-handler|SMASH-vHLLE-hybrid)-[0-9]+([.][0-9]+)?'
     local std_output
     # Unsetting PATH in the subshell so that 'git' will not be found
     std_output=$(


### PR DESCRIPTION
I noticed that I forgot to change the version title from `SMASH-vHLLE-hybrid` to `Hybrid-handler` in #85. The tags will be changed to `Hybrid-handler` from the next version on.

> [!IMPORTANT] 
> ~The version unit test will fail on local machines until the next release since `git describe` will return `SMASH-vHLLE-hybrid-2.1.3`.~ EDIT: Fixed by adapting the regex (see comments down below).