### PR TITLE
Avoid using bc command

### DIFF
--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -57,7 +57,7 @@ function Define_Repository_Global_Path()
     #       might be problematic. Hence we basically only use 'readlink' to resolve possible
     #       symbolic links. Note that we require 'readlink' to exist as this was introduced in
     #       OpenBSD and GNU around 2000, see comments to https://unix.stackexchange.com/a/136527/370049.
-    if ! hash readlink &> /dev/null; then
+    if ! type readlink &> /dev/null; then
         exit_code=${HYBRID_fatal_builtin} Print_Fatal_And_Exit \
             "No 'readlink' command found. Please install it and run the Hybrid-handler again."
     fi

--- a/Hybrid-handler
+++ b/Hybrid-handler
@@ -31,7 +31,7 @@ function Main()
     Define_Further_Global_Variables
     Parse_Execution_Mode
     Act_And_Exit_If_User_Ran_Auxiliary_Modes
-    Check_System_Requirements
+    Check_System_Requirements_And_Exit_If_Any_Is_Missing
     Parse_Command_Line_Options
     Make_Needed_Operations_Depending_On_Execution_Mode
 }

--- a/bash/Sampler_functionality.bash
+++ b/bash/Sampler_functionality.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -140,18 +140,20 @@ function __static__Check_If_Sampler_Configuration_Is_Consistent_With_Hydro()
         bulk_hydro_param=0
         ecrit_hydro=0.5
         while read key value; do
+            # NOTE: Without parentheses, awk interprets 'print v > 0' as redirecting
+            #       output to a file named "0", rather than evaluating (v > 0).
             case "${key}" in
                 etaS)
-                    shear_hydro=$(bc -l <<< "${value}>0")
+                    shear_hydro=$(awk -v v="${value}" 'BEGIN { print (v > 0) }')
                     ;;
                 etaSparam)
-                    shear_hydro_param=$(bc -l <<< "${value}>0")
+                    shear_hydro_param=$(awk -v v="${value}" 'BEGIN { print (v > 0) }')
                     ;;
                 zetaS)
-                    bulk_hydro=$(bc -l <<< "${value}>0")
+                    bulk_hydro=$(awk -v v="${value}" 'BEGIN { print (v > 0) }')
                     ;;
                 zetaSparam)
-                    bulk_hydro_param=$(bc -l <<< "${value}>0")
+                    bulk_hydro_param=$(awk -v v="${value}" 'BEGIN { print (v > 0) }')
                     ;;
                 e_crit)
                     ecrit_hydro=${value}
@@ -167,8 +169,7 @@ function __static__Check_If_Sampler_Configuration_Is_Consistent_With_Hydro()
         if [[ "${bulk_hydro}" -eq 1 || "${bulk_hydro_param}" -eq 1 ]]; then
             is_hydro_bulk=1
         fi
-        local is_sampler_shear is_sampler_bulk \
-            ecrit_sampler
+        local is_sampler_shear is_sampler_bulk ecrit_sampler
         is_sampler_shear=1
         is_sampler_bulk=0
         ecrit_sampler=0.5

--- a/bash/command_line_parsers/helper.bash
+++ b/bash/command_line_parsers/helper.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -98,7 +98,7 @@ function __static__Print_Modes_Description()
                     "${list_of_modes[${mode}]}"
             )"$'\n'
         done
-        if hash sort &> /dev/null; then
+        if type sort &> /dev/null; then
             # Remember that the 'here-string' adds a newline to the string when
             # feeding it into the command -> get rid of it here
             sort --ignore-leading-blanks <<< "${section_string%?}"

--- a/bash/formatter.bash
+++ b/bash/formatter.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -14,7 +14,7 @@ function Format_Codebase()
     local bash_format_succeeded='FALSE'
     local python_format_succeeded='FALSE'
     Ensure_That_Given_Variables_Are_Set_And_Not_Empty HYBRID_top_level_path
-    if ! hash shfmt &> /dev/null; then
+    if ! type shfmt &> /dev/null; then
         Print_Error \
             'Command ' --emph 'shfmt' ' not available. Please install it (https://github.com/mvdan/sh#shfmt)' \
             'to format the ' --emph 'Bash' ' files of the codebase.\n'
@@ -23,7 +23,7 @@ function Format_Codebase()
         shfmt -w -ln bash -i 4 -bn -ci -sr -fn "${HYBRID_top_level_path}" &> /dev/null \
             || Print_Internal_And_Exit 'Bash formatter ' --emph 'shfmt' ' unexpectedly failed.'
     fi
-    if ! hash autopep8 &> /dev/null; then
+    if ! type autopep8 &> /dev/null; then
         Print_Error \
             'Command ' --emph 'autopep8' ' not available. Please install it (https://pypi.org/project/autopep8)' \
             'to format the ' --emph 'Python' ' files of the codebase.\n'

--- a/bash/system_requirements.bash
+++ b/bash/system_requirements.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -365,7 +365,7 @@ function __static__Print_Report_Of_Requirements_With_Minimum_version()
     else
         Print_Internal_And_Exit 'Unexpected call of ' --emph "${FUNCNAME}" ' function.'
     fi
-    if hash sort &> /dev/null; then
+    if type sort &> /dev/null; then
         # The sorting column must take into account hidden color codes seen by sort and
         # here we want to sort using either the program/module name; remember that the
         # the 'here-string' adds a newline to the string when feeding it into the command.
@@ -434,7 +434,10 @@ function __static__Print_Formatted_Binary_Report()
 
 function __static__Try_Find_Requirement()
 {
-    if hash "$1" 2> /dev/null; then
+    # since hash builtin unconditionally returns 0 if a name with a slash is passed to
+    # it (https://stackoverflow.com/a/42362142), prefer using type builtin here. Hash
+    # might also fail if a command was hashed but PATH changed afterwards.
+    if type "$1" &> /dev/null; then
         return 0
     else
         return 1
@@ -444,7 +447,7 @@ function __static__Try_Find_Requirement()
 function __static__Try_Find_Version()
 {
     Ensure_That_Given_Variables_Are_Set_And_Not_Empty "system_information[$1]"
-    if ! hash grep &> /dev/null && [[ $1 != 'bash' ]]; then
+    if ! type grep &> /dev/null && [[ $1 != 'bash' ]]; then
         system_information["$1"]+='?|---'
         return 1
     fi
@@ -496,7 +499,7 @@ function __static__Check_Version_Suffices()
 function __static__Is_Gnu_Version_In_Use()
 {
     # This follows apparently common sense -> https://stackoverflow.com/a/61767587/14967071
-    if ! hash grep &> /dev/null || ! "$1" --version &> /dev/null; then
+    if ! type grep &> /dev/null || ! "$1" --version &> /dev/null; then
         return 2
     elif [[ $("$1" --version | grep -c 'GNU') -gt 0 ]]; then
         return 0

--- a/bash/system_requirements.bash
+++ b/bash/system_requirements.bash
@@ -47,7 +47,7 @@ function __static__Declare_System_Requirements()
     fi
 }
 
-function Check_System_Requirements()
+function Check_System_Requirements_And_Exit_If_Any_Is_Missing()
 {
     __static__Declare_System_Requirements
     # NOTE: The following associative array will be used to store system information
@@ -85,7 +85,7 @@ function Check_System_Requirements_And_Make_Report()
     __static__Declare_System_Requirements
     local system_report=()
     local -r single_field_length=18 # This variable is used to prepare the report correctly formatted
-    declare -A system_information   # Same use of this variable as in 'Check_System_Requirements' function
+    declare -A system_information   # Same use as in 'Check_System_Requirements_And_Exit_If_Any_Is_Missing' function
     # Define colors for all reports
     local -r \
         emph_color='\e[96m' \

--- a/bash/utility_functions.bash
+++ b/bash/utility_functions.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -657,7 +657,7 @@ function Make_Functions_Defined_In_This_File_Readonly()
     # Make this function a no-op if sed or grep are not available, so that
     # the system-requirements check does not weirdly fail in those cases just
     # because this function is called when sourcing the files at the end.
-    if ! hash sed &> /dev/null || ! hash grep &> /dev/null; then
+    if ! type sed &> /dev/null || ! type grep &> /dev/null; then
         return
     fi
     # Here we assume all functions are defined with the same stile,

--- a/tests/tests_runner
+++ b/tests/tests_runner
@@ -114,7 +114,7 @@ function Print_Helper_And_Exit_If_Requested()
 
 function Check_System_Requirements_For_Tests()
 {
-    Check_System_Requirements
+    Check_System_Requirements_And_Exit_If_Any_Is_Missing
     if ! Is_Python_Requirement_Satisfied 'packaging' &> /dev/null; then
         exit_code=${HYBRID_fatal_missing_requirement} Print_Fatal_And_Exit \
             'Python ' --emph 'packaging' ' module needed to run tests.'

--- a/tests/unit_tests_formatting.bash
+++ b/tests/unit_tests_formatting.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2025
+#    Copyright (c) 2023-2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -10,7 +10,7 @@
 function Unit_Test__codebase-formatting-Bash()
 {
     local formatter_found='FALSE'
-    if hash shfmt &> /dev/null; then
+    if type shfmt &> /dev/null; then
         formatter_found='TRUE'
     else
         Print_Error 'Command ' --emph 'shfmt' \
@@ -70,7 +70,7 @@ function Unit_Test__codebase-formatting-Bash()
 function Unit_Test__codebase-formatting-Python()
 {
     local formatter_found='FALSE'
-    if hash autopep8 &> /dev/null; then
+    if type autopep8 &> /dev/null; then
         formatter_found='TRUE'
     else
         Print_Error 'Command ' --emph 'autopep8' \

--- a/tests/unit_tests_scan_values_operations.bash
+++ b/tests/unit_tests_scan_values_operations.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2024
+#    Copyright (c) 2024,2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -60,7 +60,7 @@ function Unit_Test__scan-create-list-LHS()
         ['Hydro.Software_keys.etaS']='[-0.13, 0.17]'
     )
     Call_Codebase_Function Create_List_Of_Parameters_Values
-    local lower_bound upper_bound actual_values value
+    local lower_bound upper_bound actual_values value out_of_bounds
     for key in "${!list_of_parameters_values[@]}"; do
         lower_bound=$(yq '.[0]' <<< "${ranges[${key}]}")
         upper_bound=$(yq '.[1]' <<< "${ranges[${key}]}")
@@ -71,7 +71,12 @@ function Unit_Test__scan-create-list-LHS()
             return 1
         fi
         for value in "${actual_values[@]}"; do
-            if (($(bc <<< "${value} < ${lower_bound}"))) || (($(bc <<< "${value} > ${upper_bound}"))); then
+            out_of_bounds=$(
+                awk -v v="${value}" \
+                    -v low="${lower_bound}" \
+                    -v high="${upper_bound}" 'BEGIN { print (v < low || v > high) }'
+            )
+            if ((${out_of_bounds})); then
                 Print_Error "Parameter values list for key ${key} was not correctly created."
                 return 1
             fi

--- a/tests/unit_tests_system_requirements.bash
+++ b/tests/unit_tests_system_requirements.bash
@@ -96,7 +96,7 @@ function Unit_Test__system-requirements()
     sed_version=4.2.1
     tput_version=5.9
     yq_version=4.24.2
-    Call_Codebase_Function_In_Subshell Check_System_Requirements
+    Call_Codebase_Function_In_Subshell Check_System_Requirements_And_Exit_If_Any_Is_Missing
     if [[ $? -ne 0 ]]; then
         Print_Error "Check system requirements of good system failed."
         return 1
@@ -125,7 +125,7 @@ function Unit_Test__system-requirements()
     tput_version=''
     yq_version=3.9.98
     printf '\n'
-    Call_Codebase_Function_In_Subshell Check_System_Requirements &> /dev/null
+    Call_Codebase_Function_In_Subshell Check_System_Requirements_And_Exit_If_Any_Is_Missing &> /dev/null
     if [[ $? -eq 0 ]]; then
         Print_Error "Check system requirements of bad system succeeded."
         return 1

--- a/tests/unit_tests_system_requirements.bash
+++ b/tests/unit_tests_system_requirements.bash
@@ -1,6 +1,6 @@
 #===================================================
 #
-#    Copyright (c) 2023-2024
+#    Copyright (c) 2023-2024,2026
 #      Hybrid-handler Team
 #
 #    GNU General Public License (GPLv3 or later)
@@ -57,6 +57,16 @@ function __static__Inhibit_Commands_Version()
     }
 }
 
+function __static__Make_Grep_Independent_From_Environment_Path_Search()
+{
+    # We want to mimic a bad system later to mimic failures in the system requirements report, but
+    # grep is used to extract versions and we want to keep it "findable" when we unset PATH entries.
+    function grep()
+    {
+        ${stored_grep_command} "$@"
+    }
+}
+
 function Make_Test_Preliminary_Operations__system-requirements()
 {
     local file_to_be_sourced list_of_files
@@ -74,6 +84,8 @@ function Unit_Test__system-requirements()
     # find only the always required python packages, independently from OS installation.
     # Note that it needs to be set to a value to be visible from the python script.
     export HYBRID_TEST_MODE='set'
+    local -r stored_grep_command="$(type -P grep)"
+    __static__Make_Grep_Independent_From_Environment_Path_Search
     __static__Inhibit_Commands_Version
     local gnu {awk,git,sed,tput,yq}_version
     # Prepare mocked good system
@@ -121,6 +133,7 @@ function Unit_Test__system-requirements()
     printf '\n'
     (
         unset -v 'TERM'
+        export PATH=${PATH/\/usr\/bin/} # Remove /usr/bin from PATH
         Call_Codebase_Function_In_Subshell Check_System_Requirements_And_Make_Report
     )
     if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This closes #43.

I first decided to add `bc` as requirement, but then since this might not be installed I changed mind and went for using `awk`, instead, which is already a requirement. The risk of using commands that are not requirements is always there and it is already emphasised in the developer documentation.

On the way I improved a couple of aspects, see commit messages.

@RobinSattler No hurry for the review, just by the milestone deadline whenever you find time. 