### PR TITLE
Sass/spin

### DIFF
--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -48,7 +48,8 @@ function Validate_Configuration_File_Of_SMASH()
     )
     if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.2'; then
         allowed_keys+=('create_root_output')
-    elif Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.3'; then
+    fi
+    if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.3'; then
         allowed_keys+=('hydro_coordinate_system' 'compute_spin_vector' 'create_vorticity_vector_output')
     fi
 

--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -47,8 +47,11 @@ function Validate_Configuration_File_Of_SMASH()
         'ratio_pressure_energydensity'
     )
     if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.2'; then
-        allowed_keys+=('create_root_output' 'hydro_coordinate_system')
+        allowed_keys+=('create_root_output')
+    elif Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.3'; then
+        allowed_keys+=('hydro_coordinate_system' 'compute_spin_vector' 'create_vorticity_vector_output')
     fi
+
     readonly allowed_keys
     local keys_to_be_found
     keys_to_be_found=4
@@ -88,7 +91,7 @@ function Validate_Configuration_File_Of_SMASH()
                 fi
                 ((keys_to_be_found--))
                 ;;
-            shear | bulk | create_root_output)
+            shear | bulk | create_root_output | compute_spin_vector | create_vorticity_vector_output)
                 if [[ ! "${value}" =~ ^[01]$ ]]; then
                     Print_Error 'Key ' --emph "${key}" ' must be either ' \
                         --emph '0' ' or ' --emph '1' '.'

--- a/bash/system_requirements.bash
+++ b/bash/system_requirements.bash
@@ -369,7 +369,7 @@ function __static__Print_Report_Of_Requirements_With_Minimum_version()
         # The sorting column must take into account hidden color codes seen by sort and
         # here we want to sort using either the program/module name; remember that the
         # the 'here-string' adds a newline to the string when feeding it into the command.
-        sort -b -f -k${sorting_column} <<< "${report_string%?}"
+        LC_ALL=C sort -b -f -k${sorting_column} <<< "${report_string%?}"
     else
         printf '%s' "${report_string}"
     fi

--- a/configs/hadron_sampler__v3.2
+++ b/configs/hadron_sampler__v3.2
@@ -7,4 +7,3 @@ shear                         1
 cs2                           0.15
 ratio_pressure_energydensity  0.15
 create_root_output            0
-hydro_coordinate_system       tau-eta

--- a/configs/hadron_sampler__v3.3
+++ b/configs/hadron_sampler__v3.3
@@ -1,0 +1,12 @@
+surface_file                   =DEFAULT=
+output_dir                     =DEFAULT=
+number_of_events               1000
+ecrit                          0.3339
+bulk                           1
+shear                          1
+cs2                            0.15
+ratio_pressure_energydensity   0.15
+create_root_output             0
+hydro_coordinate_system        tau-eta
+compute_spin_vector            0
+create_vorticity_vector_output 0

--- a/configs/vhlle_hydro
+++ b/configs/vhlle_hydro
@@ -23,6 +23,9 @@ freezeoutOnly        1
 eosType              4
 eosTypeHadron        1
 
+freezeoutExtend      0
+vorticity            0
+
 e_crit               0.3339
 
 etaSparam            3

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -52,7 +52,9 @@ Given a version number `X.Y.Z`,
 
     :new: &nbsp; Added `Add_corona_from_IC_and_Hydro` configuration key in the `Afterburner` module, which merges the files containing corona particles from :file_folder: ***IC*** and :file_folder: ***Hydro*** into the particle lists sampled in :file_folder: ***Sampler***.
 
-    :new: &nbsp; Added new valid config key `hydro_coordinate_system`, `compute_spin_vector`, and `create_vorticity_vector_output` for SMASH sampler `3.3` to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.
+    :new: &nbsp; Added new valid config key `hydro_coordinate_system` for SMASH sampler `3.3` to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.
+
+    :new: &nbsp; Added new valid config keys `compute_spin_vector`, and `create_vorticity_vector_output` for SMASH sampler `3.3` to enable spin vector calculation all sampled particles.
 
     :new: &nbsp; The `Input_file` configuration key in the `Hydro` and `Afterburner` modules can now be used to modify the expected file names from the appropriate :file_folder: ***IC*** and :file_folder: ***Sampler*** sub-folders, when a string without a `/` character is given.
 

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -52,7 +52,7 @@ Given a version number `X.Y.Z`,
 
     :new: &nbsp; Added `Add_corona_from_IC_and_Hydro` configuration key in the `Afterburner` module, which merges the files containing corona particles from :file_folder: ***IC*** and :file_folder: ***Hydro*** into the particle lists sampled in :file_folder: ***Sampler***.
 
-    :new: &nbsp; Added new valid config key `hydro_coordinate_system` for SMASH sampler to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.
+    :new: &nbsp; Added new valid config key `hydro_coordinate_system`, `compute_spin_vector`, and `create_vorticity_vector_output` for SMASH sampler `3.3` to handle hydrodynamic simulations in Cartesian coordinates properly, additional to the runs in tau-eta frame.
 
     :new: &nbsp; The `Input_file` configuration key in the `Hydro` and `Afterburner` modules can now be used to modify the expected file names from the appropriate :file_folder: ***IC*** and :file_folder: ***Sampler*** sub-folders, when a string without a `/` character is given.
 

--- a/tests/integration_tests_sanity_checks.bash
+++ b/tests/integration_tests_sanity_checks.bash
@@ -43,13 +43,13 @@ function __static__Test_Picked_Base_Config_For_Version()
 function Integration_Test__pick-correct-base-config()
 {
     declare -A IC_cases=(
-        [3.1]='smash_IC__v3.1.yaml'
-        [3.2]='smash_IC__v3.2.yaml'
-        [3.2.1]='smash_IC__v3.2.yaml'
+        ['3.1']='smash_IC__v3.1.yaml'
+        ['3.2']='smash_IC__v3.2.yaml'
+        ['3.2.1']='smash_IC__v3.2.yaml'
     )
     declare -A Sampler_cases=(
-        [2.42.666]='hadron_sampler__v0.0'
-        [3.2]='hadron_sampler__v3.2'
+        ['2.42.666']='hadron_sampler__v0.0'
+        ['3.2']='hadron_sampler__v3.2'
     )
     local key v
     for key in 'IC' 'Sampler'; do

--- a/tests/integration_tests_sanity_checks.bash
+++ b/tests/integration_tests_sanity_checks.bash
@@ -50,6 +50,7 @@ function Integration_Test__pick-correct-base-config()
     declare -A Sampler_cases=(
         ['2.42.666']='hadron_sampler__v0.0'
         ['3.2']='hadron_sampler__v3.2'
+        ['3.3']='hadron_sampler__v3.3'
     )
     local key v
     for key in 'IC' 'Sampler'; do

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -262,6 +262,15 @@ function Unit_Test__Sampler-validate-config-file-SMASH()
             --emph "${HYBRID_software_version[Sampler]}" ' failed.'
         return 1
     fi
+    HYBRID_software_version[Sampler]='3.3'
+    __static__Validate_Config_File_For_Fixed_Version_SMASH
+    if [[ $? -ne 0 ]]; then
+        Print_Error \
+            'Validation of sampler configuration file for version ' \
+            --emph "${HYBRID_software_version[Sampler]}" ' failed.'
+        return 1
+    fi
+
     # Config file with incorrect value type for optional keys
     for wrong_key_value in \
         'bulk true' \
@@ -269,7 +278,9 @@ function Unit_Test__Sampler-validate-config-file-SMASH()
         'cs2 +-1' \
         'ratio_pressure_energydensity +-1' \
         'create_root_output True' \
-        'hydro_coordinate_system +-1'; do
+        'hydro_coordinate_system +-1' \
+        'compute_spin_vector True' \
+        'create_vorticity_vector_output True'; do
         __static__Validate_Given_Configuration_File_SMASH \
             "'${wrong_key_value}' should not be accepted" "${mandatory_config_keys[@]}" "${wrong_key_value}"
         __static__Possibly_Fail_Validation_Test $? || return 1

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -341,6 +341,24 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-validate-shipped-co
     Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
+function Make_Test_Preliminary_Operations__Sampler-validate-shipped-config-file-SMASH-ge-3.3()
+{
+    __static__Do_Preliminary_Sampler_Setup_Operations
+    export MOCK_ECHO_VERSION=3.3
+    Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
+    readonly HYBRIDT_sampler_base_config_filename='hadron_sampler__v3.3'
+}
+
+function Unit_Test__Sampler-validate-shipped-config-file-SMASH-ge-3.3()
+{
+    Unit_Test__Sampler-validate-shipped-config-file-SMASH-lt-3.2
+}
+
+function Clean_Tests_Environment_For_Following_Test__Sampler-validate-shipped-config-file-SMASH-ge-3.3()
+{
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
+}
+
 function Make_Test_Preliminary_Operations__Sampler-validate-config-file-FIST()
 {
     Make_Test_Preliminary_Operations__Sampler-create-input-file-FIST

--- a/tests/unit_tests_scan_validation.bash
+++ b/tests/unit_tests_scan_validation.bash
@@ -165,8 +165,8 @@ function Unit_Test__scan-global-validation()
         || ! Element_In_Array_Equals_To 'Hydro.Software_keys.etaS' "${!list_of_parameters_values[@]}"; then
         Print_Error 'Storing of scanning information unexpectedly failed (missing/wrong keys).'
         return 1
-    elif [[ "${list_of_parameters_values[IC.Software_keys.Modi.Collider.Sqrtsnn]}" != '{Values: [4.3, 7.7]}' ]] \
-        || [[ "${list_of_parameters_values[Hydro.Software_keys.etaS]}" != '{Values: [0.13, 0.15, 0.17]}' ]]; then
+    elif [[ "${list_of_parameters_values['IC.Software_keys.Modi.Collider.Sqrtsnn']}" != '{Values: [4.3, 7.7]}' ]] \
+        || [[ "${list_of_parameters_values['Hydro.Software_keys.etaS']}" != '{Values: [0.13, 0.15, 0.17]}' ]]; then
         Print_Error 'Storing of scanning information unexpectedly failed (wrong values).'
         return 1
     fi

--- a/tests/unit_tests_scan_values_operations.bash
+++ b/tests/unit_tests_scan_values_operations.bash
@@ -27,8 +27,8 @@ function Unit_Test__scan-create-list()
         [Hydro.Software_keys.etaS]='{Values: [0.13, 0.15, 0.17]}'
     )
     Call_Codebase_Function Create_List_Of_Parameters_Values
-    if [[ "${list_of_parameters_values[IC.Software_keys.Modi.Collider.Sqrtsnn]}" != '[4.3, 7.7]' ]] \
-        || [[ "${list_of_parameters_values[Hydro.Software_keys.etaS]}" != '[0.13, 0.15, 0.17]' ]]; then
+    if [[ "${list_of_parameters_values['IC.Software_keys.Modi.Collider.Sqrtsnn']}" != '[4.3, 7.7]' ]] \
+        || [[ "${list_of_parameters_values['Hydro.Software_keys.etaS']}" != '[0.13, 0.15, 0.17]' ]]; then
         Print_Error 'Parameters values list was not correctly created.'
         return 1
     fi


### PR DESCRIPTION
This PR adds support for the new spin and vorticity-related config keys.

For the sampler, the new keys are only enabled from version 3.3 on: `compute_spin_vector`, and `create_vorticity_vector_output`. I also added the new vorticity key to the Hydro config.

Additionally, I have also shifted the `hydro_coordinate_system` key to the version logic from v3.3 on, as @RobinSattler mentioned this in #93.

While doing this, I updated the sampler tests so they match the new version logic. I also ran into two unrelated test issues: shfmt complained about array keys like [3.2], so I quoted those, and the system requirements report failed on my machine because sort did not like the colored output. I fixed that by setting LC_ALL=C for that sort call.