### PR TITLE
Remove unused global variables

### DIFF
--- a/bash/global_variables.bash
+++ b/bash/global_variables.bash
@@ -148,12 +148,8 @@ function Define_Further_Global_Variables()
         [IC_corona]="particle_lists.oscar"
         [Hydro_corona]="particle_lists.oscar"
     )
-    declare -gA HYBRID_software_user_custom_input_file=(
-        [IC]=''
+    declare -gA HYBRID_software_user_custom_input_file=( # Only for stages for which it makes sense to have this feature
         [Hydro]=''
-        [Spectators]=''
-        [IC_corona]=''
-        [Hydro_corona]=''
         [Afterburner]=''
     )
     declare -gA HYBRID_software_base_config_file=(

--- a/tests/unit_tests_configuration.bash
+++ b/tests/unit_tests_configuration.bash
@@ -234,7 +234,7 @@ function __static__Test_Section_Parsing_In_Subshell()
     if [[ ${HYBRID_software_base_config_file[${section}]} != "${config_file}" ]]; then
         Print_Fatal_And_Exit 'Parsing of ' --emph "${section}" ' section failed (config file).'
     fi
-    if [[ ${input_file} != '' ]]; then # The Sampler does not support input files.
+    if [[ ${input_file} != '' ]]; then # E.g., the Sampler does not support input files.
         if [[ ${HYBRID_software_user_custom_input_file[${section}]} != "${input_file}" ]]; then
             Print_Fatal_And_Exit 'Parsing of ' --emph "${section}" ' section failed (input file).'
         fi


### PR DESCRIPTION
Following up my message on Mattermost, I simply tried to remove the variables and nothing broke.

These changes will trigger in the future errors if attempting to use these variables and, therefore, it improves maintainability.
