### PR TITLE
Remove old framework name in version unit test

### DIFF
--- a/tests/unit_tests_version.bash
+++ b/tests/unit_tests_version.bash
@@ -20,9 +20,7 @@ function Unit_Test__version()
     # be used as the repository is locally checked out effectively as a
     # black-box archive. Testing using a regex should cover all cases.
     HYBRID_codebase_version='Hybrid-handler-42.666.1'
-    # The regex includes 'SMASH-vHLLE-hybrid' to make this test 'backward-compatible'
-    # until the next release version 2.2. Afterward, this should be removed.
-    HYBRID_codebase_version_regex='(Hybrid-handler|SMASH-vHLLE-hybrid)-[0-9]+([.][0-9]+)?'
+    HYBRID_codebase_version_regex='Hybrid-handler-[0-9]+([.][0-9]+)?'
     local std_output
     # Unsetting PATH in the subshell so that 'git' will not be found
     std_output=$(


### PR DESCRIPTION
Closes #98

In PR #97 the regex to check the version in _tests/unit_tests_version.bash_ was altered to include `Hybrid-handler` as well as `SMASH-vHLLE-hybrid`. This was to maintain backward compatibility for the test until the `Hybrid-handler-2.2` release. This PR removes `SMASH-vHLLE-hybrid` from the regex.