### PR TITLE
Add SMASH-3.3 IC config

### DIFF
--- a/configs/smash_IC__v3.3.yaml
+++ b/configs/smash_IC__v3.3.yaml
@@ -1,0 +1,31 @@
+Logging:
+    default: INFO
+
+General:
+    Modus:          Collider
+    Time_Step_Mode: Fixed
+    Delta_Time:     1.0
+    End_Time:       2000.0
+    Randomseed:     -1
+    Nevents:        1
+
+Output:
+    Initial_Conditions:
+      Format: ["For_vHLLE","Oscar2013"]
+      Extended: True
+
+Modi:
+    Collider:
+        Projectile:
+            Particles: {2212: 79, 2112: 118} #Gold197
+        Target:
+            Particles: {2212: 79, 2112: 118} #Gold197
+
+        Sqrtsnn: 200.0
+        Fermi_Motion: frozen
+        Impact:
+            Max: 3.3    # 0-5% in Au+Au at 200 GeV
+
+        Initial_Conditions:
+            Type: "Constant_Tau"
+            Proper_Time_Scaling: 1.4741


### PR DESCRIPTION
I think this was forgotten in #87 / #105 but it's necessary. 

I dislike the increasing number of backwards compatible configs, and would rather create an `configs/old/` folder and just leave the most current version in `configs/` though. Might be relevant for #107 