### PR TITLE
Fix SMASH sampler spin config key and make it backward compatible

### DIFF
--- a/bash/Sampler_functionality_SMASH.bash
+++ b/bash/Sampler_functionality_SMASH.bash
@@ -50,7 +50,12 @@ function Validate_Configuration_File_Of_SMASH()
         allowed_keys+=('create_root_output')
     fi
     if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.3'; then
-        allowed_keys+=('hydro_coordinate_system' 'compute_spin_vector' 'create_vorticity_vector_output')
+        allowed_keys+=('hydro_coordinate_system' 'create_vorticity_vector_output')
+    fi
+    if Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.4'; then
+        allowed_keys+=('compute_spin_vector')
+    elif Is_Version "${HYBRID_software_version[Sampler]}" -ge '3.3'; then
+        allowed_keys+=('sample_spin')
     fi
 
     readonly allowed_keys
@@ -92,7 +97,7 @@ function Validate_Configuration_File_Of_SMASH()
                 fi
                 ((keys_to_be_found--))
                 ;;
-            shear | bulk | create_root_output | compute_spin_vector | create_vorticity_vector_output)
+            shear | bulk | create_root_output | sample_spin | compute_spin_vector | create_vorticity_vector_output)
                 if [[ ! "${value}" =~ ^[01]$ ]]; then
                     Print_Error 'Key ' --emph "${key}" ' must be either ' \
                         --emph '0' ' or ' --emph '1' '.'

--- a/configs/hadron_sampler__v3.3
+++ b/configs/hadron_sampler__v3.3
@@ -8,5 +8,5 @@ cs2                            0.15
 ratio_pressure_energydensity   0.15
 create_root_output             0
 hydro_coordinate_system        tau-eta
-compute_spin_vector            0
+sample_spin                    0
 create_vorticity_vector_output 0

--- a/configs/hadron_sampler__v3.4
+++ b/configs/hadron_sampler__v3.4
@@ -1,0 +1,12 @@
+surface_file                   =DEFAULT=
+output_dir                     =DEFAULT=
+number_of_events               1000
+ecrit                          0.3339
+bulk                           1
+shear                          1
+cs2                            0.15
+ratio_pressure_energydensity   0.15
+create_root_output             0
+hydro_coordinate_system        tau-eta
+compute_spin_vector            0
+create_vorticity_vector_output 0

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -46,6 +46,8 @@ Given a version number `X.Y.Z`,
 
 !!! work-in-progress "Unreleased"
 
+    :sos: &nbsp; The spin configuration key `sample_spin` for SMASH sampler `3.3` was omitted in the allowed keys for the sampler, i.e. Hybrid-handler `2.2` is not working with this specific sampler config key and hence not with sampler version `3.3` when using the base config. This configuration key was renamed in `SMASH sampler `3.4` to `compute_spin_vector` (breaking change) and only this new key name was mistakenly introduced as an allowed sampler configuration key in Hybrid-handler `2.2`. Now, the handler is compatible with both versions of the sampler, permitting the corresponding key for each version.
+
 
 ### Hybrid-handler-2.2
 

--- a/tests/unit_tests_Sampler_functionality.bash
+++ b/tests/unit_tests_Sampler_functionality.bash
@@ -359,6 +359,24 @@ function Clean_Tests_Environment_For_Following_Test__Sampler-validate-shipped-co
     Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
 }
 
+function Make_Test_Preliminary_Operations__Sampler-validate-shipped-config-file-SMASH-ge-3.4()
+{
+    __static__Do_Preliminary_Sampler_Setup_Operations
+    export MOCK_ECHO_VERSION=3.4
+    Perform_Sanity_Checks_On_Provided_Input_And_Define_Auxiliary_Global_Variables
+    readonly HYBRIDT_sampler_base_config_filename='hadron_sampler__v3.4'
+}
+
+function Unit_Test__Sampler-validate-shipped-config-file-SMASH-ge-3.4()
+{
+    Unit_Test__Sampler-validate-shipped-config-file-SMASH-lt-3.2
+}
+
+function Clean_Tests_Environment_For_Following_Test__Sampler-validate-shipped-config-file-SMASH-ge-3.4()
+{
+    Clean_Tests_Environment_For_Following_Test__Sampler-create-input-file-SMASH
+}
+
 function Make_Test_Preliminary_Operations__Sampler-validate-config-file-FIST()
 {
     Make_Test_Preliminary_Operations__Sampler-create-input-file-FIST


### PR DESCRIPTION
When running the hybrid chain with the test config just updating the executables' paths, the sampler run fails and the log reports an unknown key `compute_spin_vector`. I think this is a wrong parameter name and it should be `sample_spin`. I have corrected it in the places I know of, please check if this is sufficient.