### PR TITLE
Fixes in CHANGELOG and warning message

### DIFF
--- a/bash/sanity_checks.bash
+++ b/bash/sanity_checks.bash
@@ -193,8 +193,8 @@ function __static__Set_Default_Input_File_If_Unset()
             if ! Element_In_Array_Equals_To 'IC' "${HYBRID_given_software_sections[@]}"; then
                 Print_Warning \
                     'It is not possible to deduce which input file should be used for the ' \
-                    --emph 'Hydro' ' stage, \nsince the IC stage is not run. Falling back to default ' \
-                    --emph 'SMASH_IC_For_vHLLE.dat' '.\nUse the ' --emph 'Input_File' \
+                    --emph 'Hydro' ' stage,\nsince the IC stage is not run. Falling back to default ' \
+                    --emph 'SMASH_IC_For_vHLLE.dat' '.\nUse the ' --emph 'Input_file' \
                     ' key in the Hydro section to explicitly specify a filename.'
                 HYBRID_software_default_input_filename[${key}]='SMASH_IC_For_vHLLE.dat'
             else

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -65,7 +65,7 @@ Given a version number `X.Y.Z`,
 
     :new: &nbsp; The `Input_file` configuration key in the `Hydro` and `Afterburner` modules can now be used to modify the expected file names from the appropriate :file_folder: ***IC*** and :file_folder: ***Sampler*** sub-folders, when a string without a `/` character is given.
 
-    :warning: &nbsp; The parameters extracted by the [Bayesian analysis in :newspaper: *Phys. Rev. C 112, 014910*](https://journals.aps.org/prc/abstract/10.1103/rzml-rjxz) are now set as default for the base configs. The old parameters for the hydro evolution were kept in :file_folder: ***configs/predef_configs/vhlle_hydro_EPJA_58-11-230***, and the other parameters are adjusted by each handler configuration file in :file_folder: *** predef_configs***.
+    :warning: &nbsp; The parameters extracted by the [Bayesian analysis in :newspaper: *Phys. Rev. C 112, 014910*](https://journals.aps.org/prc/abstract/10.1103/rzml-rjxz) are now set as default for the base configs. The old parameters for the hydro evolution are kept in :file_folder: ***configs/predef_configs/EPJA_58-11-230***, and the other parameters are adjusted by each handler configuration file in :file_folder: ***predef_configs***.
 
     :new: &nbsp; Added configuration files for a dynamic fluidization run in :file_folder: ***configs/predef_configs/dynamic_fluidization***. This requires the specific branch [merge-review in vHLLE](https://github.com/yukarpenko/vhlle/tree/merge-review).
 
@@ -91,7 +91,7 @@ Given a version number `X.Y.Z`,
 
     :sos: &nbsp; Fix how spectators are added from the `IC` output into the `Afterburner` input file. This now works for all SMASH versions. The spectators from the target were not properly considered beforehand. Additionally, the adding of spectators is currently only allowed if only one `IC` event was run.
 
-    :recycle: &nbsp; Renamed the copied/linked afterburner inputfile containing the sampled particles (and possibly spectators) from :material-file: _sampled_particles_list.oscar_ to :material_file: _sampled_particles.oscar_. Note that this is not a breaking change because this file is created into the :file_folder: **Afterburner** folder at the beginning of such a stage.
+    :recycle: &nbsp; Renamed the copied/linked afterburner inputfile containing the sampled particles (and possibly spectators) from :material-file: _sampled_particles_list.oscar_ to :material-file: _sampled_particles.oscar_. Note that this is not a breaking change because this file is created into the :file_folder: **Afterburner** folder at the beginning of such a stage.
 
 
 ### SMASH-vHLLE-hybrid-2.1

--- a/docs/user/CHANGELOG/index.md
+++ b/docs/user/CHANGELOG/index.md
@@ -67,7 +67,7 @@ Given a version number `X.Y.Z`,
 
     :warning: &nbsp; The parameters extracted by the [Bayesian analysis in :newspaper: *Phys. Rev. C 112, 014910*](https://journals.aps.org/prc/abstract/10.1103/rzml-rjxz) are now set as default for the base configs. The old parameters for the hydro evolution are kept in :file_folder: ***configs/predef_configs/EPJA_58-11-230***, and the other parameters are adjusted by each handler configuration file in :file_folder: ***predef_configs***.
 
-    :new: &nbsp; Added configuration files for a dynamic fluidization run in :file_folder: ***configs/predef_configs/dynamic_fluidization***. This requires the specific branch [merge-review in vHLLE](https://github.com/yukarpenko/vhlle/tree/merge-review).
+    :new: &nbsp; Added configuration files for a dynamic fluidization run in :file_folder: ***configs/predef_configs/dynamic_fluidization***.
 
 ### SMASH-vHLLE-hybrid-2.1.3
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -7,7 +7,7 @@ hide:
 # A unique wonderful tool
 
 The Hybrid-handler is a :simple-gnubash: **Bash script** and therefore it does not need any installation.
-Once cloned the repository, you can simply run the `Hybrid-handler` script[^1].
+After cloning the repository or downloading the source code attached to a release, you can simply run the `Hybrid-handler` script[^1].
 
 [^1]: Be aware, that this might not work straightaway if only a very old Bash installation is available on your OS.
       However, if your Bash version is `4.x` or higher, the main script will be able to give you a complete overview of system requirements.

--- a/docs/user/predefined_configs.md
+++ b/docs/user/predefined_configs.md
@@ -36,8 +36,8 @@ They can be executed in the standard manner using `-c` option in the execution m
 
 ## Dynamic fluidization setup
 
-In order to use the dynamic initial conditions described in  [:newspaper: *Góes-Hirayama et al.: Phys.Rev.C 113 (2026) 4, 044906*](https://journals.aps.org/prc/abstract/10.1103/w87d-ps6f), very different base configuration files and are necessary.
-The base configuration files are provided in the :file_folder: **predef_configs/dynamic_fluidization** folder along with an example for central Au+Au collisions at $\small\sqrt{s} = 4.3\;\mathrm{GeV}$. 
+In order to use the dynamic initial conditions described in [:newspaper: *Góes-Hirayama et al.: Phys.Rev.C 113 (2026) 4, 044906*](https://journals.aps.org/prc/abstract/10.1103/w87d-ps6f), very different base configuration files are necessary.
+The base configuration files are provided in the :file_folder: **predef_configs/dynamic_fluidization** folder along with an example for central Au+Au collisions at $\small\sqrt{s} = 4.3\;\mathrm{GeV}$.
 After adjusting the paths to executables and the handler, it can be run in the usual manner.
 
 ``` title="Running Hybrid-handler with dynamic fluidization: Au+Au collision @ 4.3 GeV"


### PR DESCRIPTION
I noticed a couple of minor flaws, mainly in the documentation. Additionally, I removed the link to the specific vHLLE branch `merge-review` in the CHANGELOG. I think this is misleading since it's already merged into vHLLE's `main` and @zpauliny updated the requirements of the dynamic fluidization in PR #115 &ndash; specifically stating the tag that should be used for dynamic fluidization. The link to `merge-review` might even end up dead at some point in time. 

Once this has been merged, I will redeploy the documentation for version `2.2`.